### PR TITLE
Ignore bridgeport(VLAN member) netlink messages

### DIFF
--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -206,6 +206,12 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
         return;
     }
 
+    /* If this is a bridge port, return */
+    if (master)
+    {
+        return;
+    }
+
     /* In the event of swss restart, it is possible to get netlink messages during bridge
      * delete, interface delete etc which are part of cleanup. These netlink messages for
      * the front-panel interface must not be published or it will update the statedb with
@@ -236,15 +242,11 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
     vector<FieldValueTuple> temp;
     if (m_portTable.get(key, temp))
     {
-        /* Host interface is created */
-        if (!g_init && g_portSet.find(key) != g_portSet.end())
-        {
-            g_portSet.erase(key);
-            FieldValueTuple tuple("state", "ok");
-            vector<FieldValueTuple> vector;
-            vector.push_back(tuple);
-            m_statePortTable.set(key, vector);
-            SWSS_LOG_NOTICE("Publish %s(ok) to state db", key.c_str());
-        }
+        g_portSet.erase(key);
+        FieldValueTuple tuple("state", "ok");
+        vector<FieldValueTuple> vector;
+        vector.push_back(tuple);
+        m_statePortTable.set(key, vector);
+        SWSS_LOG_NOTICE("Publish %s(ok) to state db", key.c_str());
     }
 }


### PR DESCRIPTION
Also, cleanup g_init and g_portSet flag and data strcutures usage.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
For now, ignore netlink messages for bridge ports. That is 
**Why I did it**
When VLAN member is added/removed to/from a VLAN, we create/remove bridge port. This results in receiving netwlink ADD and REM message for link. When we were receiving netlink remove message for bridgeport, we were actually removing the port from state DB. But note that we have NOT deleted the port itself. Hence I decided to ignore the netlink messages fro bridge port for now. Actually we need to think on how we can make use of those messages to maintain VLAN members.

**How I verified it**
VLAN test cases in swss/tests folder failing before. After the fix, I verified that all test cases in test_vlan.py pass
**Details if related**
