### PR TITLE
VLAN dependency handling for Dynamic Port Breakout

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -53,8 +53,17 @@ public:
             FDB_DEP,
             INTF_DEP,
             LAG_DEP,
-            VLAN_DEP
+            VLAN_DEP,
+            MAX_DEP
     };
+    std::unordered_map<Dependency, std::string> 
+        m_dependency_string = {
+            {ACL_DEP, "ACL"},
+            {FDB_DEP, "FDB"},
+            {INTF_DEP, "INTF"},
+            {LAG_DEP, "LAG"},
+            {VLAN_DEP, "VLAN"}
+        };
 
     Port() {};
     Port(std::string alias, Type type) :
@@ -117,6 +126,22 @@ public:
     inline bool has_dependency()
     {
         return (m_dependency_bitmap != 0);
+    }
+    std::string print_dependency()
+    {
+        std::string deps="";
+        uint32_t dep_bitmap = m_dependency_bitmap;
+       
+        for (int dep = ACL_DEP; dep < MAX_DEP && dep_bitmap; ++dep)
+        {
+            uint32_t mask = (1 << dep);
+
+            if (dep_bitmap & mask) {
+                deps += m_dependency_string[static_cast<Dependency>(dep)] + " ";
+                dep_bitmap &= ~mask;
+            }
+        }
+        return deps; 
     }
 };
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2355,7 +2355,7 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
             }
             else
             {
-                it++; //continue?
+                it++;
             }
         }
         else if (op == DEL_COMMAND)
@@ -2387,6 +2387,7 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
             it = consumer.m_toSync.erase(it);
         }
     }
+    
 }
 
 void PortsOrch::doLagTask(Consumer &consumer)

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2144,7 +2144,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
             if (m_portList[alias].has_dependency())
             {
                 // Port has one or more dependencies, cannot remove
-                SWSS_LOG_WARN("Cannot to remove port because of dependency"); 
+                SWSS_LOG_WARN("Please remove port dependenc(y/ies):%s",
+                               m_portList[alias].print_dependency().c_str()); 
                 it++;
                 continue;
             }
@@ -2348,9 +2349,14 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
             }
 
             if (addBridgePort(port) && addVlanMember(vlan, port, tagging_mode))
+            {
+                m_portList[port.m_alias].set_dependency(Port::VLAN_DEP);
                 it = consumer.m_toSync.erase(it);
+            }
             else
-                it++;
+            {
+                it++; //continue?
+            }
         }
         else if (op == DEL_COMMAND)
         {
@@ -2361,6 +2367,8 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
                     if (port.m_vlan_members.empty())
                     {
                         removeBridgePort(port);
+                      
+                        m_portList[port.m_alias].clear_dependency(Port::VLAN_DEP);
                     }
                     it = consumer.m_toSync.erase(it);
                 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -675,6 +675,11 @@ class DockerVirtualSwitch(object):
 
         return exists, extra_info
 
+    def delete_port(self, port):
+        tbl = swsscommon.Table(self.cdb, "PORT")
+        tbl._del(port)
+        time.sleep(1)
+        
     def create_vlan(self, vlan):
         tbl = swsscommon.Table(self.cdb, "VLAN")
         fvs = swsscommon.FieldValuePairs([("vlanid", vlan)])

--- a/tests/test_port_dpb.py
+++ b/tests/test_port_dpb.py
@@ -74,7 +74,9 @@ class TestPortDPB(object):
         dpb.breakin(dvs, ["Ethernet64", "Ethernet65", "Ethernet66", "Ethernet67"])
         dpb.breakin(dvs, ["Ethernet112", "Ethernet113", "Ethernet114", "Ethernet115"])
 
+    '''
     @pytest.mark.skip()
+    '''
     def test_port_breakout_all(self, dvs):
         dpb = DPB()
         port_names = []

--- a/tests/test_port_dpb_vlan.py
+++ b/tests/test_port_dpb_vlan.py
@@ -1,0 +1,176 @@
+from swsscommon import swsscommon
+import redis
+import time
+import os
+import pytest
+from pytest import *
+import json
+import re
+from port_dpb import Port
+from port_dpb import DPB
+
+@pytest.mark.usefixtures('dpb_setup_fixture')
+class TestPortDPBVlan(object):
+    def check_syslog(self, dvs, marker, log, expected_cnt):
+        (exitcode, num) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep \"%s\" | wc -l" % (marker, log)])
+        assert num.strip() >= str(expected_cnt)
+
+    '''
+    @pytest.mark.skip()
+    '''
+    def test_dependency(self, dvs):
+        dpb = DPB() 
+        dvs.setup_db()
+        p = Port(dvs, "Ethernet0")
+        p.sync_from_config_db()
+        dvs.create_vlan("100")
+        #print "Created VLAN100"
+        dvs.create_vlan_member("100", p.get_name())
+        #print "Added Ethernet0 to VLAN100"
+        marker = dvs.add_log_marker()
+        p.delete_from_config_db()
+        #Verify that we are looping on dependency
+        time.sleep(2)
+        self.check_syslog(dvs, marker, "doPortTask: Please remove port dependenc(y/ies):VLAN", 1)
+        assert(p.exists_in_asic_db() == True)
+
+        dvs.remove_vlan_member("100", p.get_name())
+        time.sleep(2)
+        # Verify that port is deleted
+        assert(p.exists_in_asic_db() == False)
+
+        #Create the port back and delete the VLAN
+        p.write_to_config_db() 
+        #print "Added port:%s to config DB"%p.get_name()
+        p.verify_config_db()
+        #print "Config DB verification passed!"
+        p.verify_app_db()
+        #print "Application DB verification passed!"
+        p.verify_asic_db()
+        #print "ASIC DB verification passed!"
+       
+        dvs.remove_vlan("100") 
+
+    '''
+    @pytest.mark.skip()
+    '''
+    def test_one_port_one_vlan(self, dvs):
+        dpb = DPB()
+        dvs.setup_db()
+
+        # Breakout testing with VLAN dependency
+        dvs.create_vlan("100")
+        #print "Created VLAN100"
+        dvs.create_vlan_member("100", "Ethernet0")
+        #print "Added Ethernet0 to VLAN100"
+
+        p = Port(dvs, "Ethernet0")
+        p.sync_from_config_db()
+        p.delete_from_config_db()
+        assert(p.exists_in_config_db() == False)
+        assert(p.exists_in_app_db() == False)
+        assert(p.exists_in_asic_db() == True)
+        #print "Ethernet0 deleted from config DB and APP DB, waiting to be removed from VLAN"
+
+        dvs.remove_vlan_member("100", "Ethernet0")
+        assert(p.exists_in_asic_db() == False)
+        #print "Ethernet0 removed from VLAN and also from ASIC DB"
+
+        dpb.create_child_ports(dvs, p, 4)
+
+        # Breakin testing with VLAN dependency
+        port_names = ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"]
+        for pname in port_names:
+            dvs.create_vlan_member("100", pname)
+        #print "Add %s to VLAN"%port_names            
+
+        child_ports = []
+        for pname in port_names:
+            cp = Port(dvs, pname)
+            cp.sync_from_config_db()
+            cp.delete_from_config_db()
+            assert(cp.exists_in_config_db() == False)
+            assert(cp.exists_in_app_db() == False)
+            assert(cp.exists_in_asic_db() == True)
+            child_ports.append(cp)
+        #print "Deleted %s from config DB and APP DB"%port_names            
+
+        for cp in child_ports:
+            dvs.remove_vlan_member("100", cp.get_name())
+            time.sleep(1)
+            assert(cp.exists_in_asic_db() == False)
+        #print "Deleted %s from VLAN"%port_names            
+
+        p.write_to_config_db() 
+        #print "Added port:%s to config DB"%p.get_name()
+        p.verify_config_db()
+        #print "Config DB verification passed!"
+        p.verify_app_db()
+        #print "Application DB verification passed!"
+        p.verify_asic_db()
+        #print "ASIC DB verification passed!"
+
+        dvs.remove_vlan("100")
+
+    @pytest.mark.skip()
+    def test_one_port_multiple_vlan(self, dvs):
+        dpb = DPB()
+        dvs.setup_db()
+
+        dvs.create_vlan("100")
+        dvs.create_vlan("101")
+        dvs.create_vlan("102")
+        #print "Created VLAN100, VLAN101, and VLAN102"
+        dvs.create_vlan_member("100", "Ethernet0")
+        dvs.create_vlan_member("101", "Ethernet0")
+        dvs.create_vlan_member("102", "Ethernet0")
+        #print "Added Ethernet0 to all three VLANs"
+
+        p = Port(dvs, "Ethernet0")
+        p.sync_from_config_db()
+        p.delete_from_config_db()
+        assert(p.exists_in_config_db() == False)
+        assert(p.exists_in_app_db() == False)
+        assert(p.exists_in_asic_db() == True)
+        #print "Ethernet0 deleted from config DB and APP DB, waiting to be removed from VLANs"
+
+        dvs.remove_vlan_member("100", "Ethernet0")
+        assert(p.exists_in_asic_db() == True)
+        #print "Ethernet0 removed from VLAN100 and its still present in ASIC DB"
+
+        dvs.remove_vlan_member("101", "Ethernet0")
+        assert(p.exists_in_asic_db() == True)
+        #print "Ethernet0 removed from VLAN101 and its still present in ASIC DB"
+
+        dvs.remove_vlan_member("102", "Ethernet0")
+        assert(p.exists_in_asic_db() == False)
+        #print "Ethernet0 removed from VLAN101 and also from ASIC DB"
+
+        dpb.create_child_ports(dvs, p, 4)
+        #print "1X40G ---> 4x10G verified"
+
+        # Breakin
+        port_names = ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"]
+        for pname in port_names:
+            cp = Port(dvs, pname)
+            cp.sync_from_config_db()
+            cp.delete_from_config_db()
+            assert(cp.exists_in_config_db() == False)
+            assert(cp.exists_in_app_db() == False)
+            assert(cp.exists_in_asic_db() == False)
+        #print "Deleted %s and verified all DBs"%port_names            
+
+        #Add back Ethernet0
+        p.write_to_config_db() 
+        p.verify_config_db()
+        p.verify_app_db()
+        p.verify_asic_db()
+        #print "Added port:%s and verified all DBs"%p.get_name()
+
+        # Remove all three VLANs
+        dvs.remove_vlan("100")
+        dvs.remove_vlan("101")
+        dvs.remove_vlan("102")
+        #print "All three VLANs removed"
+
+

--- a/tests/test_port_dpb_vlan.py
+++ b/tests/test_port_dpb_vlan.py
@@ -112,7 +112,9 @@ class TestPortDPBVlan(object):
 
         dvs.remove_vlan("100")
 
+    '''    
     @pytest.mark.skip()
+    '''
     def test_one_port_multiple_vlan(self, dvs):
         dpb = DPB()
         dvs.setup_db()


### PR DESCRIPTION
    Set port::VLAN_DEP bit when port is added to first VLAN
    Clear port::VLAN_DEP bit when port is removed from all VLANs
During port removal check for the dependency bit map.

Also added, pretty printing of dependency list

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Code changes in portsorch to handle VLAN dependency on port.
    -Set port::VLAN_DEP bit when port is added to first VLAN
    -Clear port::VLAN_DEP bit when port is removed from all VLANs . 
    -During port removal check for the dependency bit map.

2. Also added pretty printing of dependency list
3. Refactored DPB test infra code.
4. Added test cases for VLAN dependency testing


**Why I did it**
To support DPB feature
**How I verified it**
Ran all VS test cases, and also newly added VLAN DPB test cases.

**Details if related**
======================================================================= test session starts ========================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python                                                                          
cachedir: .cache                                                                                                                                                    
rootdir: /home/vapatil/workspace/XU_DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 182 items                                                                                                                                                

test_acl.py::TestAcl::test_AclTableCreation PASSED                                                                                                           [  0%]
test_acl.py::TestAcl::test_AclRuleL4SrcPort PASSED                                                                                                           [  1%]
test_acl.py::TestAcl::test_AclRuleInOutPorts PASSED                                                                                                          [  1%]
test_acl.py::TestAcl::test_AclTableDeletion PASSED                                                                                                           [  2%]
test_acl.py::TestAcl::test_V6AclTableCreation PASSED                                                                                                         [  2%]
test_acl.py::TestAcl::test_V6AclRuleIPv6Any PASSED                                                                                                           [  3%]
test_acl.py::TestAcl::test_V6AclRuleIPv6AnyDrop PASSED                                                                                                       [  3%]
test_acl.py::TestAcl::test_V6AclRuleIpProtocol PASSED                                                                                                        [  4%]
test_acl.py::TestAcl::test_V6AclRuleSrcIPv6 PASSED                                                                                                           [  4%]
test_acl.py::TestAcl::test_V6AclRuleDstIPv6 PASSED                                                                                                           [  5%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPort PASSED                                                                                                         [  6%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPort PASSED                                                                                                         [  6%]
test_acl.py::TestAcl::test_V6AclRuleTCPFlags PASSED                                                                                                          [  7%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPortRange PASSED                                                                                                    [  7%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPortRange PASSED                                                                                                    [  8%]
test_acl.py::TestAcl::test_V6AclTableDeletion PASSED                                                                                                         [  8%]
test_acl.py::TestAcl::test_InsertAclRuleBetweenPriorities PASSED                                                                                             [  9%]
test_acl.py::TestAcl::test_RulesWithDiffMaskLengths PASSED                                                                                                   [  9%]
test_acl.py::TestAcl::test_AclRuleIcmp PASSED                                                                                                                [ 10%]
test_acl.py::TestAcl::test_AclRuleIcmpV6 PASSED                                                                                                              [ 10%]
test_acl.py::TestAclRuleValidation::test_AclActionValidation PASSED                                                                                          [ 11%]
test_acl_ctrl.py::TestPortChannelAcl::test_AclCtrl PASSED                                                                                                    [ 12%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclTableCreation PASSED                                                                             [ 12%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclRuleL4SrcPortRange PASSED                                                                        [ 13%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclRuleL4DstPortRange PASSED                                                                        [ 13%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclRuleL2EthType PASSED                                                                             [ 14%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclRuleTunnelVNI PASSED                                                                             [ 14%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclRuleTC PASSED                                                                                    [ 15%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclInnerIPProtocol PASSED                                                                           [ 15%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclInnerEthType PASSED                                                                              [ 16%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclInnerL4SrcPort PASSED                                                                            [ 17%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclInnerL4DstPort PASSED                                                                            [ 17%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclTableDeletion PASSED                                                                             [ 18%]
test_acl_portchannel.py::TestPortChannelAcl::test_PortChannelAfterAcl PASSED                                                                                 [ 18%]
test_acl_portchannel.py::TestPortChannelAcl::test_PortChannelBeforeAcl PASSED                                                                                [ 19%]
test_acl_portchannel.py::TestPortChannelAcl::test_AclOnPortChannelMember PASSED                                                                              [ 19%]
test_admin_status.py::TestAdminStatus::test_PortChannelMemberAdminStatus PASSED                                                                              [ 20%]
test_crm.py::TestCrm::test_CrmFdbEntry PASSED                                                                                                                [ 20%]
test_crm.py::TestCrm::test_CrmIpv4Route PASSED                                                                                                               [ 21%]
test_crm.py::TestCrm::test_CrmIpv6Route PASSED                                                                                                               [ 21%]
test_crm.py::TestCrm::test_CrmIpv4Nexthop PASSED                                                                                                             [ 22%]
test_crm.py::TestCrm::test_CrmIpv6Nexthop PASSED                                                                                                             [ 23%]
test_crm.py::TestCrm::test_CrmIpv4Neighbor PASSED                                                                                                            [ 23%]
test_crm.py::TestCrm::test_CrmIpv6Neighbor PASSED                                                                                                            [ 24%]
test_crm.py::TestCrm::test_CrmNexthopGroup PASSED                                                                                                            [ 24%]
test_crm.py::TestCrm::test_CrmNexthopGroupMember PASSED                                                                                                      [ 25%]
test_crm.py::TestCrm::test_CrmAcl PASSED                                                                                                                     [ 25%]
test_crm.py::TestCrm::test_CrmAclGroup PASSED                                                                                                                [ 26%]
test_crm.py::TestCrm::test_Configure PASSED                                                                                                                  [ 26%]
test_crm.py::TestCrm::test_Configure_ipv4_route PASSED                                                                                                       [ 27%]
test_crm.py::TestCrm::test_Configure_ipv6_route PASSED                                                                                                       [ 28%]
test_crm.py::TestCrm::test_Configure_ipv4_nexthop PASSED                                                                                                     [ 28%]
test_crm.py::TestCrm::test_Configure_ipv6_nexthop PASSED                                                                                                     [ 29%]
test_crm.py::TestCrm::test_Configure_ipv4_neighbor PASSED                                                                                                    [ 29%]
test_crm.py::TestCrm::test_Configure_ipv6_neighbor PASSED                                                                                                    [ 30%]
test_crm.py::TestCrm::test_Configure_group_member PASSED                                                                                                     [ 30%]
test_crm.py::TestCrm::test_Configure_group_object PASSED                                                                                                     [ 31%]
test_crm.py::TestCrm::test_Configure_acl_table PASSED                                                                                                        [ 31%]
test_crm.py::TestCrm::test_Configure_acl_group PASSED                                                                                                        [ 32%]
test_crm.py::TestCrm::test_Configure_acl_group_entry PASSED                                                                                                  [ 32%]
test_crm.py::TestCrm::test_Configure_acl_group_counter PASSED                                                                                                [ 33%]
test_crm.py::TestCrm::test_Configure_fdb PASSED                                                                                                              [ 34%]
test_dirbcast.py::TestDirectedBroadcast::test_DirectedBroadcast PASSED                                                                                       [ 34%]
test_dtel.py::TestDtel::test_DtelGlobalAttribs PASSED                                                                                                        [ 35%]
test_dtel.py::TestDtel::test_DtelReportSessionAttribs PASSED                                                                                                 [ 35%]
test_dtel.py::TestDtel::test_DtelINTSessionAttribs PASSED                                                                                                    [ 36%]
test_dtel.py::TestDtel::test_DtelQueueReportAttribs PASSED                                                                                                   [ 36%]
test_dtel.py::TestDtel::test_DtelEventAttribs PASSED                                                                                                         [ 37%]
test_fdb.py::TestFdb::test_FdbWarmRestartNotifications PASSED                                                                                                [ 37%]
test_fdb.py::TestFdb::test_FdbAddedAfterMemberCreated PASSED                                                                                                 [ 38%]
test_fdb_update.py::test_FDBAddedAndUpdated PASSED                                                                                                           [ 39%]
test_fdb_update.py::test_FDBLearnedAndUpdated PASSED                                                                                                         [ 39%]
test_interface.py::TestRouterInterface::test_InterfaceAddRemoveIpv6Address PASSED                                                                            [ 40%]
test_interface.py::TestRouterInterface::test_InterfaceAddRemoveIpv4Address PASSED                                                                            [ 40%]
test_interface.py::TestRouterInterface::test_InterfaceSetMtu PASSED                                                                                          [ 41%]
test_interface.py::TestLagRouterInterfaceIpv4::test_InterfaceAddRemoveIpv4Address PASSED                                                                     [ 41%]
test_interface.py::TestLagRouterInterfaceIpv4::test_InterfaceSetMtu PASSED                                                                                   [ 42%]
test_interface.py::TestLoopbackRouterInterface::test_InterfacesCreateRemove PASSED                                                                           [ 42%]
test_mirror.py::TestMirror::test_MirrorAddRemove PASSED                                                                                                      [ 43%]
test_mirror.py::TestMirror::test_MirrorToVlanAddRemove PASSED                                                                                                [ 43%]
test_mirror.py::TestMirror::test_MirrorToLagAddRemove PASSED                                                                                                 [ 44%]
test_mirror.py::TestMirror::test_MirrorDestMoveVlan PASSED                                                                                                   [ 45%]
test_mirror.py::TestMirror::test_MirrorDestMoveLag PASSED                                                                                                    [ 45%]
test_mirror.py::TestMirror::test_AclBindMirrorPerStage PASSED                                                                                                [ 46%]
test_mirror.py::TestMirror::test_AclBindMirror PASSED                                                                                                        [ 46%]
test_mirror_ipv6_combined.py::TestMirror::test_AclBindMirrorV6Combined FAILED                                                                                [ 47%]
test_mirror_ipv6_combined.py::TestMirror::test_AclBindMirrorV6Reorder1 FAILED                                                                                [ 47%]
test_mirror_ipv6_combined.py::TestMirror::test_AclBindMirrorV6Reorder2 FAILED                                                                                [ 48%]
test_mirror_ipv6_combined.py::TestMirror::test_AclBindMirrorV6WrongConfig FAILED                                                                             [ 48%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorSeparated FAILED                                                                                 [ 49%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorV6Reorder1 FAILED                                                                                [ 50%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorV6Reorder2 FAILED                                                                                [ 50%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorV6WrongConfig FAILED                                                                             [ 51%]
test_mirror_policer.py::TestMirror::test_MirrorPolicer PASSED                                                                                                [ 51%]
test_mirror_policer.py::TestMirror::test_MirrorPolicerWithAcl PASSED                                                                                         [ 52%]
test_nhg.py::TestNextHopGroup::test_route_nhg PASSED                                                                                                         [ 52%]
test_pfc.py::TestPfc::test_PfcAsymmetric PASSED                                                                                                              [ 53%]
test_policer.py::TestPolicer::test_PolicerBasic PASSED                                                                                                       [ 53%]
test_port.py::TestPort::test_PortMtu PASSED                                                                                                                  [ 54%]
test_port.py::TestPort::test_PortNotification PASSED                                                                                                         [ 54%]
test_port.py::TestPort::test_PortFec PASSED                                                                                                                  [ 55%]
test_port.py::TestPort::test_PortPreemp PASSED                                                                                                               [ 56%]
test_port.py::TestPort::test_PortIdriver PASSED                                                                                                              [ 56%]
test_port.py::TestPort::test_PortIpredriver PASSED                                                                                                           [ 57%]
test_port_an.py::TestPortAutoNeg::test_PortAutoNegCold PASSED                                                                                                [ 57%]
test_port_an.py::TestPortAutoNeg::test_PortAutoNegWarm PASSED                                                                                                [ 58%]
test_port_buffer_rel.py::TestPortBuffer::test_PortsAreUpAfterBuffers PASSED                                                                                  [ 58%]
test_port_config.py::TestPortConfig::test_port_hw_lane PASSED                                                                                                [ 59%]
test_port_config.py::TestPortConfig::test_port_breakout PASSED                                                                                               [ 59%]
test_port_dpb.py::TestPortDPB::test_port_breakout_one PASSED                                                                                                 [ 60%]
test_port_dpb.py::TestPortDPB::test_port_breakout_multiple vapatil
PASSED                                                                                            [ 60%]
test_port_dpb.py::TestPortDPB::test_port_breakout_all SKIPPED                                                                                                [ 61%]
test_port_dpb_acl.py::TestPortDPBAcl::test_acl_table_empty_port_list PASSED                                                                                  [ 62%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_two_acl_tables PASSED                                                                                    [ 62%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_acl_table_many_ports PASSED                                                                                   [ 63%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_many_acl_tables SKIPPED                                                                                  [ 63%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_dependency FAILED                                                                                               [ 64%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_one_vlan FAILED                                                                                        [ 64%]
test_portchannel.py::TestPortchannel::test_Portchannel PASSED                                                                                                [ 65%]
test_portchannel.py::TestPortchannel::test_Portchannel_oper_down PASSED                                                                                      [ 65%]
test_qos_map.py::TestDot1p::test_dot1p_cfg PASSED                                                                                                            [ 66%]
test_qos_map.py::TestDot1p::test_port_dot1p PASSED                                                                                                           [ 67%]
test_route.py::TestRoute::test_RouteAdd PASSED                                                                                                               [ 67%]
test_setro.py::TestSetRo::test_SetReadOnlyAttribute PASSED                                                                                                   [ 68%]
test_sflow.py::TestSflow::test_SflowDisble PASSED                                                                                                            [ 68%]
test_sflow.py::TestSflow::test_InterfaceSet PASSED                                                                                                           [ 69%]
test_sflow.py::TestSflow::test_ConfigDel PASSED                                                                                                              [ 69%]
test_speed.py::TestSpeedSet::test_SpeedAndBufferSet PASSED                                                                                                   [ 70%]
test_switch.py::TestSwitch::test_switch_attribute PASSED                                                                                                     [ 70%]
test_tunnel.py::TestDecapTunnel::test_TunnelDecap_v4 PASSED                                                                                                  [ 71%]
test_tunnel.py::TestDecapTunnel::test_TunnelDecap_v6 PASSED                                                                                                  [ 71%]
test_tunnel.py::TestSymmetricTunnel::test_TunnelSymmetric_v4 PASSED                                                                                          [ 72%]
test_tunnel.py::TestSymmetricTunnel::test_TunnelSymmetric_v6 PASSED                                                                                          [ 73%]
test_vlan.py::TestVlan::test_VlanAddRemove PASSED                                                                                                            [ 73%]
test_vlan.py::TestVlan::test_MultipleVlan PASSED                                                                                                             [ 74%]
test_vlan.py::TestVlan::test_VlanIncrementalConfig PASSED                                                                                                    [ 74%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input0-0] PASSED                                                                             [ 75%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input1-0] PASSED                                                                             [ 75%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input2-0] PASSED                                                                             [ 76%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input3-1] PASSED                                                                             [ 76%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input0-0] PASSED                                                                             [ 77%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input1-0] PASSED                                                                             [ 78%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input2-0] PASSED                                                                             [ 78%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input3-1] PASSED                                                                             [ 79%]
test_vlan.py::TestVlan::test_AddPortChannelToVlan PASSED                                                                                                     [ 79%]
test_vlan.py::TestVlan::test_AddVlanMemberWithNonExistVlan PASSED                                                                                            [ 80%]
test_vlan.py::TestVlan::test_RemoveNonexistentVlan PASSED                                                                                                    [ 80%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input0-expected0] PASSED                                                                             [ 81%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input1-expected1] PASSED                                                                             [ 81%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input2-expected2] PASSED                                                                             [ 82%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input3-expected3] PASSED                                                                             [ 82%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input4-expected4] PASSED                                                                             [ 83%]
test_vlan.py::TestVlan::test_AddMaxVlan SKIPPED                                                                                                              [ 84%]
test_vlan.py::TestVlan::test_RemoveVlanWithRouterInterface PASSED                                                                                            [ 84%]
test_vlan.py::TestVlan::test_VlanDbData PASSED                                                                                                               [ 85%]
test_vlan.py::TestVlan::test_VlanMemberDbData[test_input0-expected0] PASSED                                                                                  [ 85%]
test_vlan.py::TestVlan::test_VlanMemberDbData[test_input1-expected1] PASSED                                                                                  [ 86%]
test_vlan.py::TestVlan::test_VlanMemberDbData[test_input2-expected2] PASSED                                                                                  [ 86%]
test_vnet.py::TestVnetOrch::test_vnet_orch_1 PASSED                                                                                                          [ 87%]
test_vnet.py::TestVnetOrch::test_vnet_orch_2 PASSED                                                                                                          [ 87%]
test_vnet.py::TestVnetOrch::test_vnet_orch_3 PASSED                                                                                                          [ 88%]
test_vnet.py::TestVnetOrch::test_vnet_orch_4 SKIPPED                                                                                                         [ 89%]
test_vnet.py::TestVnetOrch::test_vnet_orch_5 PASSED                                                                                                          [ 89%]
test_vnet_bitmap.py::TestVnetBitmapOrch::test_vnet_orch_1 <- test_vnet.py FAILED                                                                             [ 90%]
test_vnet_bitmap.py::TestVnetBitmapOrch::test_vnet_orch_2 <- test_vnet.py FAILED                                                                             [ 90%]
test_vnet_bitmap.py::TestVnetBitmapOrch::test_vnet_orch_3 <- test_vnet.py FAILED                                                                             [ 91%]
test_vnet_bitmap.py::TestVnetBitmapOrch::test_vnet_orch_4 <- test_vnet.py SKIPPED                                                                            [ 91%]
test_vnet_bitmap.py::TestVnetBitmapOrch::test_vnet_orch_5 <- test_vnet.py FAILED                                                                             [ 92%]
test_vrf.py::TestVrf::test_VRFOrch_Comprehensive PASSED                                                                                                      [ 92%]
test_vrf.py::TestVrf::test_VRFOrch PASSED                                                                                                                    [ 93%]
test_vrf.py::TestVrf::test_VRFOrch_Update PASSED                                                                                                             [ 93%]
test_vxlan_tunnel.py::TestVxlan::test_vxlan_term_orch PASSED                                                                                                 [ 94%]
test_warm_reboot.py::TestWarmReboot::test_PortSyncdWarmRestart PASSED                                                                                        [ 95%]
test_warm_reboot.py::TestWarmReboot::test_VlanMgrdWarmRestart PASSED                                                                                         [ 95%]
test_warm_reboot.py::TestWarmReboot::test_swss_neighbor_syncup PASSED                                                                                        [ 96%]
test_warm_reboot.py::TestWarmReboot::test_OrchagentWarmRestartReadyCheck PASSED                                                                              [ 96%]
test_warm_reboot.py::TestWarmReboot::test_swss_port_state_syncup PASSED                                                                                      [ 97%]
test_warm_reboot.py::TestWarmReboot::test_routing_WarmRestart PASSED                                                                                         [ 97%]
test_warm_reboot.py::TestWarmReboot::test_system_warmreboot_neighbor_syncup PASSED                                                                           [ 98%]
test_watermark.py::TestWatermark::test_telemetry_period PASSED                                                                                               [ 98%]
test_watermark.py::TestWatermark::test_lua_plugins SKIPPED                                                                                                   [ 99%]
test_watermark.py::TestWatermark::test_clear SKIPPED                                                                                                         [100%]

14 failed, 161 passed, 7 skipped in 6888.49 seconds
Failed test cases:
8 -> Mirror test cases
4 -> Vnet bitmap test cases
2-> Newly added VLAN DPB test cases. Issue was in script, fixed and re-ran the test cases. They were success.
=============================================================================================== test session starts ================================================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/XU_DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 3 items                                                                                                                                                                                                  

test_port_dpb_vlan.py::TestPortDPBVlan::test_dependency remove extra link dummy
PASSED                                                                                                                                               [ 33%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_one_vlan PASSED                                                                                                                                        [ 66%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_multiple_vlan SKIPPED                                                                                                                                  [100%]

====================================================================================== 2 passed, 1 skipped in 121.09 seconds =======================================================================================

Updated Test results for VLAN DPB test cases:
vapatil@server09:~/workspace/XU_DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -v --dvsname=vs-vp --pdb test_port_dpb_vlan.py
=============================================================================================== test session starts ================================================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/XU_DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 3 items                                                                                                                                                                                                  

test_port_dpb_vlan.py::TestPortDPBVlan::test_dependency remove extra link dummy
Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f22476d1dc8>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f22476d1dc8> = <_sre.SRE_Match object at 0x7f22476d1dc8>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f22477d1250>> ignored
PASSED                                                                                                                                               [ 33%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_one_vlan PASSED                                                                                                                                        [ 66%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_multiple_vlan PASSED                                                                                                                                   [100%]Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f22476b2378>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f22476b2378> = <_sre.SRE_Match object at 0x7f22476b2378>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f224769f390>> ignored


============================================================================================ 3 passed in 156.82 seconds ============================================================================================
vapatil@server09:~/workspace/XU_DPB/sonic-buildimage/src/sonic-swss/tests$ 

