### PR TITLE
Flush fdb entries when port/LAG is operational down

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -159,7 +159,8 @@ void FdbOrch::update(sai_fdb_event_t type, const sai_fdb_entry_t* entry, sai_obj
         break;
 
     case SAI_FDB_EVENT_FLUSHED:
-        if (bridge_port_id == SAI_NULL_OBJECT_ID && entry->bv_id == SAI_NULL_OBJECT_ID)
+        if ((bridge_port_id == SAI_NULL_OBJECT_ID && entry->bv_id == SAI_NULL_OBJECT_ID)
+            || (bridge_port_id && entry->bv_id == SAI_NULL_OBJECT_ID))
         {
             for (auto itr = m_entries.begin(); itr != m_entries.end();)
             {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2590,7 +2590,7 @@ void PortsOrch::doLagTask(Consumer &consumer)
                         if (getPort(alias, lag))
                         {
                             SWSS_LOG_NOTICE("Flushing FDB entries for %s with bridge port id: %" PRIx64
-                                "as it is DOWN", alias.c_str(), lag.m_bridge_port_id);
+                                " as it is DOWN", alias.c_str(), lag.m_bridge_port_id);
                             flushFDBEntries(lag.m_bridge_port_id);
                         }
                     }
@@ -3745,7 +3745,7 @@ void PortsOrch::doTask(NotificationConsumer &consumer)
             if (status == SAI_PORT_OPER_STATUS_DOWN)
             {
                 SWSS_LOG_NOTICE("Flushing FDB entries for %s with bridge port id: %" PRIx64
-                    "as it is DOWN", port.m_alias.c_str(), port.m_bridge_port_id);
+                    " as it is DOWN", port.m_alias.c_str(), port.m_bridge_port_id);
                 flushFDBEntries(port.m_bridge_port_id);
             }
 
@@ -3949,6 +3949,6 @@ void PortsOrch::flushFDBEntries(sai_object_id_t bridge_port_id)
 
     if (rv != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_WARN("Flush fdb by bridge port id: %" PRIx64 "failed: %d", bridge_port_id, rv);
+        SWSS_LOG_ERROR("Flush fdb by bridge port id: %" PRIx64 "failed: %d", bridge_port_id, rv);
     }
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -35,6 +35,7 @@ extern sai_hostif_api_t* sai_hostif_api;
 extern sai_acl_api_t* sai_acl_api;
 extern sai_queue_api_t *sai_queue_api;
 extern sai_object_id_t gSwitchId;
+extern sai_fdb_api_t *sai_fdb_api;
 extern IntfsOrch *gIntfsOrch;
 extern NeighOrch *gNeighOrch;
 extern CrmOrch *gCrmOrch;
@@ -2585,6 +2586,13 @@ void PortsOrch::doLagTask(Consumer &consumer)
                     if (fvValue(i) == "down")
                     {
                         gNeighOrch->ifChangeInformNextHop(alias, false);
+                        Port lag;
+                        if (getPort(alias, lag))
+                        {
+                            SWSS_LOG_NOTICE("Flushing FDB entries for %s with bridge port id: %" PRIx64
+                                "as it is DOWN", alias.c_str(), lag.m_bridge_port_id);
+                            flushFDBEntries(lag.m_bridge_port_id);
+                        }
                     }
                     else
                     {
@@ -3734,6 +3742,13 @@ void PortsOrch::doTask(NotificationConsumer &consumer)
 
             updatePortOperStatus(port, status);
 
+            if (status == SAI_PORT_OPER_STATUS_DOWN)
+            {
+                SWSS_LOG_NOTICE("Flushing FDB entries for %s with bridge port id: %" PRIx64
+                    "as it is DOWN", port.m_alias.c_str(), port.m_bridge_port_id);
+                flushFDBEntries(port.m_bridge_port_id);
+            }
+
             /* update m_portList */
             m_portList[port.m_alias] = port;
         }
@@ -3916,5 +3931,24 @@ void PortsOrch::getPortSerdesVal(const std::string& val_str,
     {
         lane_val = (uint32_t)std::stoul(lane_str, NULL, 16);
         lane_values.push_back(lane_val);
+    }
+}
+
+void PortsOrch::flushFDBEntries(sai_object_id_t bridge_port_id)
+{
+    sai_attribute_t attr;
+    vector<sai_attribute_t> attrs;
+    sai_status_t rv;
+
+    SWSS_LOG_INFO("Flushing the port with bridge port id: %" PRIx64, bridge_port_id);
+
+    attr.id = SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID;
+    attr.value.oid = bridge_port_id;
+    attrs.push_back(attr);
+    rv = sai_fdb_api->flush_fdb_entries(gSwitchId, (uint32_t)attrs.size(), attrs.data());
+
+    if (rv != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Flush fdb by bridge port id: %" PRIx64 "failed: %d", bridge_port_id, rv);
     }
 }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -149,7 +149,7 @@ private:
     map<string, uint32_t> m_port_ref_count;
     unordered_set<string> m_pendingPortSet;
 
-	
+
     NotificationConsumer* m_portStatusNotificationConsumer;
 
     void doTask(Consumer &consumer);
@@ -230,6 +230,8 @@ private:
                                 vector<uint32_t> &serdes_val);
     bool getSaiAclBindPointType(Port::Type                type,
 		                sai_acl_bind_point_type_t &sai_acl_bind_type);
+
+    void flushFDBEntries(sai_object_id_t bridge_port_id);
 };
 #endif /* SWSS_PORTSORCH_H */
 


### PR DESCRIPTION
Flush fdb entries when port/LAG is operational down

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Flush fdb entries when port/LAG is operational down

**Why I did it**
To support DPB, we want to remove fdb entries when we shutdown port/LAG

**How I verified it**
vs test cases to be added.

**Details if related**

```
zxu@server09:~/SONIC/sonic-buildimage-brcm/src/sonic-swss/tests$ sudo pytest -v --dvsname=vs-xu test_fdb_update.py
====================================================================================== test session starts ======================================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/zxu/SONIC/sonic-buildimage-brcm/src/sonic-swss/tests, inifile:
collected 3 items                                                                                                                                                                               

test_fdb_update.py::test_FDBAddedAndUpdated PASSED                                                                                                                                        [ 33%]
test_fdb_update.py::test_FDBLearnedAndUpdated PASSED                                                                                                                                      [ 66%]
test_fdb_update.py::test_FDBLearnedAndFlushed PASSED                                                                                                                                      [100%]

================================================================================== 3 passed in 100.74 seconds ===================================================================================
```