### PR TITLE
Dynamic Port Breakout(DPB) neighbor dependency:

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -348,8 +348,10 @@ void NeighOrch::doTask(Consumer &consumer)
 
             if (m_syncdNeighbors.find(neighbor_entry) == m_syncdNeighbors.end() || m_syncdNeighbors[neighbor_entry] != mac_address)
             {
-                if (addNeighbor(neighbor_entry, mac_address))
+                if (addNeighbor(neighbor_entry, mac_address)) {
+                    gPortsOrch->increasePortNeighRefCount(p.m_alias);
                     it = consumer.m_toSync.erase(it);
+                }
                 else
                     it++;
             }
@@ -363,6 +365,7 @@ void NeighOrch::doTask(Consumer &consumer)
             {
                 if (removeNeighbor(neighbor_entry))
                 {
+                    gPortsOrch->decreasePortNeighRefCount(p.m_alias);
                     it = consumer.m_toSync.erase(it);
                 }
                 else

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -55,6 +55,7 @@ public:
             INTF_DEP,
             LAG_DEP,
             VLAN_DEP,
+            NEIGH_DEP,
             MAX_DEP
     };
     std::unordered_map<Dependency, std::string> 
@@ -108,6 +109,8 @@ public:
     vlan_members_t      m_vlan_members;
     uint32_t            m_dependency_bitmap = 0;
     sai_object_id_t     m_parent_port_id = 0;
+    uint32_t            m_neigh_ref_count = 0;
+
     sai_port_oper_status_t m_oper_status = SAI_PORT_OPER_STATUS_UNKNOWN;
     std::set<std::string> m_members;
     std::set<std::string> m_child_ports;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3918,3 +3918,29 @@ void PortsOrch::getPortSerdesVal(const std::string& val_str,
         lane_values.push_back(lane_val);
     }
 }
+
+void PortsOrch::increasePortNeighRefCount(const string &alias)
+{
+    Port p;
+    getPort(alias, p);
+    p.m_neigh_ref_count ++;
+    SWSS_LOG_NOTICE("Increase Port %s neigh ref count to: %d", p.m_alias.c_str(), p.m_neigh_ref_count);
+    p.set_dependency(Port::NEIGH_DEP);
+    setPort(alias, p);
+}
+
+void PortsOrch::decreasePortNeighRefCount(const string &alias)
+{
+    Port p;
+    getPort(alias, p);
+    if (p.m_neigh_ref_count > 0)
+        p.m_neigh_ref_count --;
+
+    SWSS_LOG_NOTICE("Decrease Port %s neigh ref count to: %d", p.m_alias.c_str(), p.m_neigh_ref_count);
+
+    if (p.m_neigh_ref_count == 0) {
+        SWSS_LOG_NOTICE("Port %s neigh ref count %d: clear dependency", p.m_alias.c_str(), p.m_neigh_ref_count);
+        p.clear_dependency(Port::NEIGH_DEP);
+    }
+    setPort(alias, p);
+}

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -105,6 +105,9 @@ public:
 
     bool addSubPort(Port &port, const string &alias, const bool &adminUp = true, const uint32_t &mtu = 0);
     bool removeSubPort(const string &alias);
+
+    void increasePortNeighRefCount(const string &alias);
+    void decreasePortNeighRefCount(const string &alias);
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_portTable;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -941,6 +941,21 @@ class DockerVirtualSwitch(object):
         acl_table_groups = atbl.getKeys()
         assert len(acl_table_groups) == len(bind_ports)
 
+    def create_l3_intf(self, interface, vrf_name):
+        tbl = swsscommon.Table(self.cdb, "INTERFACE")
+        if len(vrf_name) == 0:
+            fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        else:
+            fvs = swsscommon.FieldValuePairs([("vrf_name", vrf_name)])
+        tbl.set(interface, fvs)
+        time.sleep(1)
+
+    def create_route_entry(self, key, pairs):
+        tbl = swsscommon.ProducerStateTable(self.pdb, "ROUTE_TABLE")
+        fvs = swsscommon.FieldValuePairs(pairs)
+        tbl.set(key, fvs)
+        time.sleep(1)
+
 @pytest.yield_fixture(scope="module")
 def dvs(request):
     name = request.config.getoption("--dvsname")

--- a/tests/test_port_dpb_neigh.py
+++ b/tests/test_port_dpb_neigh.py
@@ -1,0 +1,241 @@
+from swsscommon import swsscommon
+import redis
+import time
+import os
+import pytest
+import json
+import re
+from port_dpb import DPB
+
+@pytest.mark.usefixtures('dpb_setup_fixture')
+class TestPortDPBNeigh(object):
+    def clear_srv_config(self, dvs):
+        dvs.servers[0].runcmd("ip address flush dev eth0")
+        dvs.servers[1].runcmd("ip address flush dev eth0")
+
+    def test_set_neighbor_DPB(self, dvs, testlog):
+        dvs.setup_db()
+
+        # bring up interface
+        dvs.set_interface_status("Ethernet0", "up")
+
+        # create interface and get rif_oid
+        rif_oid = dvs.create_l3_intf("Ethernet0", "")
+
+        # assign IP to interface
+        dvs.add_ip_address("Ethernet0", "10.0.0.1/24")
+
+        # add neighbor
+        dvs.set_neighbor("Ethernet0", "10.0.0.2", "00:01:02:03:04:05")
+
+        # check application database
+        tbl = swsscommon.Table(dvs.pdb, "NEIGH_TABLE:Ethernet0")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 1
+        assert intf_entries[0] == "10.0.0.2"
+        (status, fvs) = tbl.get(intf_entries[0])
+        assert status == True
+        assert len(fvs) == 2
+        for fv in fvs:
+            if fv[0] == "neigh":
+                assert fv[1] == "00:01:02:03:04:05"
+            elif fv[0] == "family":
+                assert fv[1] == "IPv4"
+            else:
+                assert False
+
+        # check ASIC neighbor database
+        tbl = swsscommon.Table(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 1
+        route = json.loads(intf_entries[0])
+        assert route["ip"] == "10.0.0.2"
+        #assert route["rif"] == rif_oid
+
+        (status, fvs) = tbl.get(intf_entries[0])
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS":
+                assert fv[1] == "00:01:02:03:04:05"
+
+        # remove ip address on interface
+        dvs.remove_ip_address("Ethernet0", "10.0.0.1/24")
+
+        # bring down interface
+        dvs.set_interface_status("Ethernet0", "down")
+
+        # check application database
+        tbl = swsscommon.Table(dvs.pdb, "NEIGH_TABLE:Ethernet0")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+        # check ASIC neighbor database
+        tbl = swsscommon.Table(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+        # Breakout Ethernet0
+        dpb = DPB()
+        dpb.breakout(dvs, "Ethernet0", 4)
+        time.sleep(2)
+
+        # Breakin Ethernet0
+        dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
+        time.sleep(2)
+
+    def test_arp_neigh_DPB(self, dvs, testlog):
+        dvs.setup_db()
+        self.clear_srv_config(dvs)
+
+        # create l3 interface
+        dvs.create_l3_intf("Ethernet0", "")
+
+        # set ip address
+        dvs.add_ip_address("Ethernet0", "10.0.0.0/31")
+
+        # bring up interface
+        dvs.set_interface_status("Ethernet0", "up")
+
+        # set server ip address and default route
+        dvs.servers[0].runcmd("ip address add 10.0.0.1/31 dev eth0")
+        dvs.servers[0].runcmd("ip route add default via 10.0.0.0")
+
+        # get neighbor and arp entry
+        dvs.servers[0].runcmd("ping -c 1 10.0.0.0")
+
+        # check application database
+        tbl = swsscommon.Table(dvs.pdb, "NEIGH_TABLE:Ethernet0")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 1
+        assert intf_entries[0] == "10.0.0.1"
+        (status, fvs) = tbl.get(intf_entries[0])
+        assert status == True
+
+        # remove ip address on interface
+        dvs.remove_ip_address("Ethernet0", "10.0.0.0/31")
+
+        # bring down interface
+        dvs.set_interface_status("Ethernet0", "down")
+
+        # Breakout Ethernet0
+        dpb = DPB()
+        dpb.breakout(dvs, "Ethernet0", 4)
+        time.sleep(2)
+
+        # Breakin Ethernet0
+        dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
+        time.sleep(2)
+
+    def test_nexthop_DPB(self, dvs, testlog):
+        dvs.setup_db()
+        self.clear_srv_config(dvs)
+
+        # create l3 interface
+        dvs.create_l3_intf("Ethernet0", "")
+
+        # set ip address
+        dvs.add_ip_address("Ethernet0", "10.0.0.0/31")
+
+        # bring up interface
+        dvs.set_interface_status("Ethernet0", "up")
+
+        # set server ip address and default route
+        dvs.servers[0].runcmd("ip address add 10.0.0.1/31 dev eth0")
+        dvs.servers[0].runcmd("ip address add 2.2.2.0/24 dev eth0")
+        time.sleep(2)
+
+        # add route and next hop
+        dvs.runcmd("ip route add 2.2.2.0/24 nexthop via 10.0.0.1")
+        dvs.runcmd("ping -c 1 2.2.2.0 -I Ethernet0")
+        time.sleep(1)
+
+        # check application database
+        tbl = swsscommon.Table(dvs.pdb, "ROUTE_TABLE")
+        route_entries = tbl.getKeys()
+        assert "2.2.2.0/24" in route_entries
+
+        # check ASIC neighbor interface database
+        tbl = swsscommon.Table(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP")
+        nexthop_entries = tbl.getKeys()
+        for key in nexthop_entries:
+            (status, fvs) = tbl.get(key)
+            assert status == True
+            for fv in fvs:
+                if fv[0] == "SAI_NEXT_HOP_ATTR_IP" and fv[1] == "10.0.0.1":
+                    nexthop_found = True
+                    nexthop_oid = key
+
+        assert nexthop_found == True
+
+        # remove route and next hop
+        dvs.runcmd("ip route delete 2.2.2.0/24 nexthop via 10.0.0.1")
+
+        # remove ip address
+        dvs.remove_ip_address("Ethernet0", "10.0.0.0/31")
+
+        # bring down interface
+        dvs.set_interface_status("Ethernet0", "down")
+        time.sleep(2)
+
+        # Breakout Ethernet0
+        dpb = DPB()
+        dpb.breakout(dvs, "Ethernet0", 4)
+        time.sleep(2)
+
+        # Breakin Ethernet0
+        dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
+        time.sleep(2)
+
+    def test_route_DPB(self, dvs, testlog):
+        dvs.setup_db()
+        self.clear_srv_config(dvs)
+
+        # create l3 interface
+        dvs.create_l3_intf("Ethernet0", "")
+
+        # set ip address
+        dvs.add_ip_address("Ethernet0", "10.0.0.0/31")
+
+        # bring up interface
+        dvs.set_interface_status("Ethernet0", "up")
+
+        # set server ip address and default route
+        dvs.servers[0].runcmd("ip address add 10.0.0.1/31 dev eth0")
+        dvs.servers[0].runcmd("ip address add 2.2.2.0/24 dev eth0")
+
+        # add route entry
+        dvs.runcmd("vtysh -c \"configure terminal\" -c \"ip route 2.2.2.0/24 10.0.0.1\"")
+        time.sleep(1)
+
+        dvs.runcmd("ping -c 1 2.2.2.0 -I Ethernet0")
+
+        # check application database
+        tbl = swsscommon.Table(dvs.pdb, "ROUTE_TABLE")
+        route_entries = tbl.getKeys()
+        assert "2.2.2.0/24" in route_entries
+        time.sleep(1)
+
+        # check ASIC route database
+        tbl = swsscommon.Table(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
+        for key in tbl.getKeys():
+            route = json.loads(key)
+            if route["dest"] == "2.2.2.0/24":
+                route_found = True
+        assert route_found == True
+        time.sleep(2)
+
+        # remove ip address
+        dvs.remove_ip_address("Ethernet0", "10.0.0.0/31")
+
+        # bring down interface
+        dvs.set_interface_status("Ethernet0", "down")
+        time.sleep(2)
+
+        # Breakout Ethernet0
+        dpb = DPB()
+        dpb.breakout(dvs, "Ethernet0", 4)
+        time.sleep(2)
+
+        # Breakin Ethernet0
+        dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
+        time.sleep(2)


### PR DESCRIPTION
  - Add neighbor reference count and neighbor dependency set/clear for Port
  - neigbor/nexthop/route vs tests for DPB

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
      Add neighbor reference count and neighbor dependency set/clear for Port

**Why I did it**
     Make sure no neighbors on the port when deleting the port for Dynamic port breakout

**How I verified it**
vs tests:
  -   Add neighbors in Config DB,  shutdown the port and breakout and breakin the port
  -  Add IP and route on the. interface,  ping it from server,   shutdown the port and breakout and breakin the port to verify the dependencies
  -  Add route and nexthop on the interface, shutdown the port and breakout and breakin the port to verify the dependencies
  -  Add route on the interface, ping it from server,   shutdown the port and breakout and breakin the port


sudo pytest  -v --dvsname=vs-pm test_port_dpb_neigh.py
============================================================================ test session starts ============================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/pmao/sonic1/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 4 items                                                                                                                                                           

test_port_dpb_neigh.py::TestPortDPBNeigh::test_set_neighbor_DPB PASSED                                                                                                [ 25%]
test_port_dpb_neigh.py::TestPortDPBNeigh::test_arp_neigh_DPB PASSED                                                                                                   [ 50%]
test_port_dpb_neigh.py::TestPortDPBNeigh::test_nexthop_DPB PASSED                                                                                                     [ 75%]
test_port_dpb_neigh.py::TestPortDPBNeigh::test_route_DPB PASSED                                                                                                       [100%]

======================================================================== 4 passed in 212.14 seconds ========================================================================
**Details if related**
