### PR TITLE
Fix the DPB baseline code based on the new state machine of portConfigState

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -874,13 +874,13 @@ bool PortsOrch::setPortPfcAsym(Port &port, string pfc_asym)
  *
  * Description:
  *     To bind a port to ACL table we need to do two things.
- *     1. Create ACL table member, which maps 
+ *     1. Create ACL table member, which maps
  *        ACL table group OID --> ACL table OID
  *     2. Set ACL table group OID as value port attribute.
  *
  *      This function performs the second step of binding.
  *
- *      Also, while unbinding we use this function to 
+ *      Also, while unbinding we use this function to
  *      set port attribute value to SAI_NULL_OBJECT_ID
  *
  *      Port attribute name is derived from port type
@@ -959,10 +959,10 @@ bool PortsOrch::unbindRemoveAclTableGroup(sai_object_id_t  port_oid,
     }
 
 
-    sai_object_id_t &group_oid_ref = 
+    sai_object_id_t &group_oid_ref =
             ingress? port.m_ingress_acl_table_group_id :
                      port.m_egress_acl_table_group_id;
-    unordered_set<sai_object_id_t> &acl_list_ref = 
+    unordered_set<sai_object_id_t> &acl_list_ref =
             ingress ? port.m_ingress_acl_tables_uset :
                       port.m_egress_acl_tables_uset;
 
@@ -973,7 +973,7 @@ bool PortsOrch::unbindRemoveAclTableGroup(sai_object_id_t  port_oid,
     }
     assert(acl_list_ref.find(acl_table_oid) != acl_list_ref.end());
     acl_list_ref.erase(acl_table_oid);
-    if (!acl_list_ref.empty()) 
+    if (!acl_list_ref.empty())
     {
         // This port is in more than one acl table's port list
         // So, we need to preserve group OID
@@ -1004,7 +1004,7 @@ bool PortsOrch::unbindRemoveAclTableGroup(sai_object_id_t  port_oid,
         SWSS_LOG_ERROR("Unknown SAI ACL bind point type");
         return false;
     }
-    gCrmOrch->decCrmAclUsedCounter(CrmResourceType::CRM_ACL_GROUP, 
+    gCrmOrch->decCrmAclUsedCounter(CrmResourceType::CRM_ACL_GROUP,
                                    ingress ? SAI_ACL_STAGE_INGRESS : SAI_ACL_STAGE_EGRESS,
                                    bind_type, group_oid_ref);
 
@@ -1013,9 +1013,9 @@ bool PortsOrch::unbindRemoveAclTableGroup(sai_object_id_t  port_oid,
     return true;
 }
 
-bool PortsOrch::createBindAclTableGroup(sai_object_id_t  port_oid, 
-                                        sai_object_id_t  acl_table_oid, 
-                                        sai_object_id_t  &group_oid, 
+bool PortsOrch::createBindAclTableGroup(sai_object_id_t  port_oid,
+                                        sai_object_id_t  acl_table_oid,
+                                        sai_object_id_t  &group_oid,
                                         acl_stage_type_t acl_stage)
 {
     SWSS_LOG_ENTER();
@@ -1029,7 +1029,7 @@ bool PortsOrch::createBindAclTableGroup(sai_object_id_t  port_oid,
 
     sai_status_t    status;
     Port            port;
-    bool            ingress = (ACL_STAGE_INGRESS == acl_stage) ? 
+    bool            ingress = (ACL_STAGE_INGRESS == acl_stage) ?
                               true : false;
     if (!getPort(port_oid, port))
     {
@@ -1037,14 +1037,14 @@ bool PortsOrch::createBindAclTableGroup(sai_object_id_t  port_oid,
         return false;
     }
 
-    unordered_set<sai_object_id_t> &acl_list_ref = 
+    unordered_set<sai_object_id_t> &acl_list_ref =
             ingress ? port.m_ingress_acl_tables_uset :
                       port.m_egress_acl_tables_uset;
-    sai_object_id_t &group_oid_ref = 
+    sai_object_id_t &group_oid_ref =
             ingress ? port.m_ingress_acl_table_group_id :
                       port.m_egress_acl_table_group_id;
-                            
-    if (acl_list_ref.empty()) 
+
+    if (acl_list_ref.empty())
     {
         // Port ACL table group does not exist, create one
         assert(group_oid_ref == SAI_NULL_OBJECT_ID);
@@ -1084,7 +1084,7 @@ bool PortsOrch::createBindAclTableGroup(sai_object_id_t  port_oid,
         assert(group_oid_ref != SAI_NULL_OBJECT_ID);
 
         gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_GROUP,
-                        ingress ? SAI_ACL_STAGE_INGRESS : 
+                        ingress ? SAI_ACL_STAGE_INGRESS :
                                   SAI_ACL_STAGE_EGRESS, bind_type);
 
         // Bind ACL table group
@@ -1095,7 +1095,7 @@ bool PortsOrch::createBindAclTableGroup(sai_object_id_t  port_oid,
 
         port.set_dependency(Port::ACL_DEP);
 
-        SWSS_LOG_NOTICE("Create %s ACL table group and bind port %s to it", 
+        SWSS_LOG_NOTICE("Create %s ACL table group and bind port %s to it",
                         ingress ? "ingress" : "egress", port.m_alias.c_str());
     }
 
@@ -1965,7 +1965,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
              * 2. Create new ports
              * 3. Initialize all ports
              */
-            if (m_portConfigState == PORT_CONFIG_RECEIVED)
+            if (m_portConfigState == PORT_CONFIG_RECEIVED || m_portConfigState == PORT_CONFIG_DONE)
             {
                 for (auto it = m_portListLaneMap.begin(); it != m_portListLaneMap.end();)
                 {
@@ -2307,7 +2307,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
             {
                 // Port has one or more dependencies, cannot remove
                 SWSS_LOG_WARN("Please remove port dependenc(y/ies):%s",
-                               m_portList[alias].print_dependency().c_str()); 
+                               m_portList[alias].print_dependency().c_str());
                 it++;
                 continue;
             }
@@ -2529,7 +2529,7 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
                     if (port.m_vlan_members.empty())
                     {
                         removeBridgePort(port);
-                      
+
                         m_portList[port.m_alias].clear_dependency(Port::VLAN_DEP);
                     }
                     it = consumer.m_toSync.erase(it);
@@ -2549,7 +2549,7 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
             it = consumer.m_toSync.erase(it);
         }
     }
-    
+
 }
 
 void PortsOrch::doLagTask(Consumer &consumer)
@@ -2663,7 +2663,7 @@ void PortsOrch::doLagTask(Consumer &consumer)
             if (m_portList[alias].has_dependency())
             {
                 // LAG has one or more dependencies, cannot remove
-                SWSS_LOG_WARN("Cannot to remove LAG because of dependency"); 
+                SWSS_LOG_WARN("Cannot to remove LAG because of dependency");
                 continue;
             }
 
@@ -3844,7 +3844,7 @@ bool PortsOrch::getSaiAclBindPointType(Port::Type           type,
             return false;
     }
     return true;
-}        
+}
 
 bool PortsOrch::removeAclTableGroup(const Port &p)
 {


### PR DESCRIPTION
Fix the DPB baseline code based on the new state machine of portConfigState

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix the DPB baseline code based on the new state machine of portConfigState

**Why I did it**
The current code won't add/remove port dynamically.

**How I verified it**
```
test_port_an.py::TestPortAutoNeg::test_PortAutoNegCold PASSED                                                                                                                 [  4%]
test_port_an.py::TestPortAutoNeg::test_PortAutoNegWarm PASSED                                                                                                                 [  8%]
test_port_buffer_rel.py::TestPortBuffer::test_PortsAreUpAfterBuffers PASSED                                                                                                   [ 12%]
test_portchannel.py::TestPortchannel::test_Portchannel PASSED                                                                                                                 [ 16%]
test_portchannel.py::TestPortchannel::test_Portchannel_oper_down PASSED                                                                                                       [ 20%]
test_port_config.py::TestPortConfig::test_port_hw_lane PASSED                                                                                                                 [ 24%]
test_port_config.py::TestPortConfig::test_port_breakout PASSED                                                                                                                [ 28%]
test_port_dpb_acl.py::TestPortDPBAcl::test_acl_table_empty_port_list PASSED                                                                                                               [ 32%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_two_acl_tables PASSED                                                                                                                 [ 36%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_acl_table_many_ports PASSED                                                                                                                [ 40%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_many_acl_tables SKIPPED                                                                                                               [ 44%]
test_port_dpb.py::TestPortDPB::test_port_breakout_one PASSED                                                                                                                              [ 48%]
test_port_dpb.py::TestPortDPB::test_port_breakout_multiple PASSED                                                                                                                         [ 52%]
test_port_dpb.py::TestPortDPB::test_port_breakout_all FAILED                                                                                                                              [ 56%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_dependency PASSED                                                                                                                            [ 60%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_one_vlan PASSED                                                                                                                     [ 64%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_multiple_vlan PASSED                                                                                                                [ 68%]
test_port_mac_learn.py::TestPortMacLearn::test_PortMacLearnMode PASSED                                                                                                                    [ 72%]
test_port_mac_learn.py::TestPortMacLearn::test_PortchannelMacLearnMode PASSED                                                                                                             [ 76%]
test_port.py::TestPort::test_PortMtu PASSED                                                                                                                                               [ 80%]
test_port.py::TestPort::test_PortNotification FAILED                                                                                                                                      [ 84%]
test_port.py::TestPort::test_PortFec FAILED                                                                                                                                               [ 88%]
test_port.py::TestPort::test_PortPreemp PASSED                                                                                                                                            [ 92%]
test_port.py::TestPort::test_PortIdriver PASSED                                                                                                                                           [ 96%]
test_port.py::TestPort::test_PortIpredriver PASSED                                                                                                                                        [100%]

```
**Details if related**
