### PR TITLE
Changing the DPB fixure to get breakout cfg table

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -962,8 +962,13 @@ def testlog(request, dvs):
     dvs.runcmd("logger === finish test %s ===" % request.node.name)
 
 ##################### DPB fixtures ###########################################
+
+HWSKU="Force10-S6000"
+
 @pytest.yield_fixture(scope="module")
 def create_dpb_config_file(dvs):
+    cmd = "sonic-cfggen -p /usr/share/sonic/hwsku/platform.json -k {} --print-data > /tmp/ports.json".format(HWSKU)
+    dvs.runcmd(['sh', '-c', cmd])
     cmd = "sonic-cfggen -j /etc/sonic/init_cfg.json -j /tmp/ports.json --print-data > /tmp/dpb_config_db.json"
     dvs.runcmd(['sh', '-c', cmd])
     cmd = "mv /etc/sonic/config_db.json /etc/sonic/config_db.json.bak"
@@ -982,3 +987,4 @@ def dpb_setup_fixture(dvs):
     dvs.restart()
     yield
     remove_dpb_config_file(dvs)
+


### PR DESCRIPTION
**What I did**

Generating  "BREAKOUT_CFG" table in config DB for running DPB test case.


**Why I did it**

This PR is needed for PR [sonic-buildimage/pull/18](https://github.com/zhenggen-xu/sonic-buildimage/pull/18)

**How I verified it**

**Details if related**
