### PR TITLE
DPB VS fix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -976,13 +976,8 @@ def testlog(request, dvs):
     dvs.runcmd("logger === finish test %s ===" % request.node.name)
 
 ##################### DPB fixtures ###########################################
-
-HWSKU="Force10-S6000"
-
 @pytest.yield_fixture(scope="module")
 def create_dpb_config_file(dvs):
-    cmd = "sonic-cfggen -p /usr/share/sonic/hwsku/platform.json -k {} --print-data > /tmp/ports.json".format(HWSKU)
-    dvs.runcmd(['sh', '-c', cmd])
     cmd = "sonic-cfggen -j /etc/sonic/init_cfg.json -j /tmp/ports.json --print-data > /tmp/dpb_config_db.json"
     dvs.runcmd(['sh', '-c', cmd])
     cmd = "mv /etc/sonic/config_db.json /etc/sonic/config_db.json.bak"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Updated dpb fixture as per changes in start.sh script in sonic-buil-image

**Why I did it**
So, that correct  configuration is generated for DPB VS test scripts

**How I verified it**
By running DPB sytem test cases

**Details if related**
sudo pytest --pdb -s -v --dvsname=vs-vp test_port_dpb_system.py 
======================================================================= test session starts ========================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 1 item                                                                                                                                                   

test_port_dpb_system.py::TestPortDPBSystem::test_port_breakout_one remove extra link dummy
**** 1X100G --> 2x50G passed ****
**** 2x50G --> 4X25G passed ****
**** 4X25G --> 2x50G passed ****
**** 2X50G --> 2x25G(2)+1x50G(2) passed ****
**** 2x25G(2)+1x50G(2) --> 2x50G passed ****
**** 2X50G --> 1x50G(2)+2x25G(2) passed ****
**** 1x50G(2)+2x25G(2) --> 2x50G passed ****
**** 2x50G --> 1x100G passed ****
**** 1x100G --> 4X25G passed ****
**** 4X25G --> 1x50G(2)+2x25G(2) passed ****
**** 1x50G(2)+2x25G(2) --> 4X25G passed ****
**** 4X25G --> 2x25G(2)+1x50G(2) passed ****
**** 2x25G(2)+1x50G(2) --> 4X25G passed ****
**** 4x25G --> 1x100G passed ****
**** 1X100G --> 1x50G(2)+2x25G(2) passed ****
**** 1x50G(2)+2x25G(2) --> 2x25G(2)+1x50G(2) passed ****
**** 2x25G(2)+1x50G(2) --> 1x50G(2)+2x25G(2) passed ****
**** 1x50G(2)+2x25G(2) --> 1x100G passed ****
**** 1x100G --> 2x25G(2)+1x50G(2) passed ****
**** 2x25G(2)+1x50G(2) --> 1x100G passed ****
PASSED                                                                                    [100%]

==================================================================== 1 passed in 170.65 seconds ====================================================================
vapatil@server09
