### PR TITLE
Do NOT call flush FDB with null bridge port ID

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4046,8 +4046,13 @@ void PortsOrch::flushFDBEntries(sai_object_id_t bridge_port_id)
     vector<sai_attribute_t> attrs;
     sai_status_t rv;
 
-    SWSS_LOG_INFO("Flushing the port with bridge port id: %" PRIx64, bridge_port_id);
+    if (SAI_NULL_OBJECT_ID == bridge_port_id)
+    {
+        SWSS_LOG_WARN("null bridge port ID");
+        return;
+    }
 
+    SWSS_LOG_INFO("Flushing the port with bridge port id: %" PRIx64, bridge_port_id);
     attr.id = SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID;
     attr.value.oid = bridge_port_id;
     attrs.push_back(attr);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1,4 +1,4 @@
-#inchude "portsorch.h"
+#include "portsorch.h"
 #include "intfsorch.h"
 #include "bufferorch.h"
 #include "neighorch.h"

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1,4 +1,4 @@
-#include "portsorch.h"
+#inchude "portsorch.h"
 #include "intfsorch.h"
 #include "bufferorch.h"
 #include "neighorch.h"
@@ -4046,9 +4046,13 @@ void PortsOrch::flushFDBEntries(sai_object_id_t bridge_port_id)
     vector<sai_attribute_t> attrs;
     sai_status_t rv;
 
+    // If bridge port ID and bvis both are are NOT specified,
+    // SAI REDIS will flush all FDB entries. This function is meant
+    // to delete passed in bridge_port_id's FDB entries only.
+    // Hence bridge_port_id cannot SAI_NULL_OBJECT_ID.
     if (SAI_NULL_OBJECT_ID == bridge_port_id)
     {
-        SWSS_LOG_WARN("null bridge port ID");
+        SWSS_LOG_WARN("NOT flushing FDB entries as bridge port ID:0x0");
         return;
     }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
If the bridge port ID is SAI_NULL_OBJECT_ID, do NOT call FDB flush

**Why I did it**
If we do so, broadcom sai API will clean all the FDB entries in that VLAN

**How I verified it**
Problem Description:
----------------------
**If you look at the below outputs (Before fix section), though we are doing port breakout on Ethernet0, Ethernet8 is affected. In this case, I moved Ethernet0 from 1x to 4x breakout mode. From the syslog, I saw that, Ethernet1 was initialized, host interface was created and momentarily its operation status was set to down. During this time, flush FDB is called without checking that Ethernet1 bridge_port_id is 0x0. Hence all FDB entries in ASIC are removed. Since traffic was flowing only via Ethernet1, its FDB entery was re-learned but Ethernet8 FDB entry was NOT learned.**

Before fix:
------------
```
admin@lnos-x1-a-asw01:~$ sudo config interface breakout Ethernet0 4x25G[10G] -f -l -v -y
Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 4x25G[10G]
Ports to be deleted :
 {
    "Ethernet0": "100000"
}
Ports to be added :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
After running Logic to limit the impact
Final list of ports to be deleted :
 {
    "Ethernet0": "100000"
}
Final list of ports to be added :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Start Port Deletion
Find dependecies for port Ethernet0
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB
Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Merge Default Config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000001b90"
(empty list or set)
Writing in Config DB
Breakout process got successfully completed.
admin@lnos-x1-a-asw01:~$
admin@lnos-x1-a-asw01:~$ sudo /usr/bin/nbrshow -4
Address                  HWtype  HWaddress           Flags Mask            Iface
10.11.10.12              ether   00:12:01:00:00:01   C                     Vlan100
10.2.1.0                 ether   00:e0:ec:3b:da:41   C                     Ethernet116
172.21.47.1              ether   00:ee:ab:9f:d3:d9   C                     eth0
10.11.10.11              ether   00:11:01:00:00:01   C                     Vlan100
172.21.47.11             ether   bc:16:65:b3:ce:8e   C                     eth0
10.1.1.0                 ether   00:e0:ec:3b:d8:35   C                     Ethernet112
> /usr/bin/nbrshow(128)display()
-> for ent in self.nbrdata:
(Pdb) c
Address       MacAddress         Iface        Vlan
------------  -----------------  -----------  ------
10.1.1.0      00:e0:ec:3b:d8:35  Ethernet112  -
10.2.1.0      00:e0:ec:3b:da:41  Ethernet116  -
10.11.10.11   00:11:01:00:00:01  Ethernet1    100
10.11.10.12   00:12:01:00:00:01  -            100
172.21.47.1   00:ee:ab:9f:d3:d9  eth0         -
172.21.47.11  bc:16:65:b3:ce:8e  eth0         -
Total number of entries 6
admin@lnos-x1-a-asw01:~$ redis-cli
127.0.0.1:6379> select 1
OK
127.0.0.1:6379[1]> keys *FDB*
1) "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:{\"bvid\":\"oid:0x2600000000177e\",\"mac\":\"00:11:01:00:00:01\",\"switch_id\":\"oid:0x21000000000000\"}"
127.0.0.1:6379[1]>
```

syslog:
```

Mar 19 01:00:36.713322 lnos-x1-a-asw01 NOTICE swss#orchagent: :- doTask: Get port state change notification id:1000000002082 status:2
Mar 19 01:00:36.713649 lnos-x1-a-asw01 NOTICE swss#orchagent: :- updatePortOperStatus: Port Ethernet1 oper state set from up to down
Mar 19 01:00:36.715534 lnos-x1-a-asw01 NOTICE swss#orchagent: :- setHostIntfsOperStatus: Set operation status DOWN to host interface Ethernet1
Mar 19 01:00:36.715829 lnos-x1-a-asw01 NOTICE swss#orchagent: :- doTask: Flushing FDB entries for Ethernet1 with bridge port id: 0 as it is DOWN
Mar 19 01:00:36.715960 lnos-x1-a-asw01 NOTICE swss#orchagent: :- internal_redis_flush_fdb_entries: flush key: SAI_OBJECT_TYPE_FDB_FLUSH:oid:0x21000000000000, fields: 1
Mar 19 01:00:36.786068 lnos-x1-a-asw01 NOTICE swss#orchagent: :- internal_redis_flush_fdb_entries: flush status: 0
Mar 19 01:00:36.967491 lnos-x1-a-asw01 NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet0 admin:0 oper:0 addr:00:e0:ec:3c:0a:0a ifindex:536 master:0
```
After fix:
---------
I tried at-least 5 times and did NOT see the issue. Also verified from syslog that when bridge port ID is 0x0, we do NOT call SAI redis flush API
```
admin@lnos-x1-a-asw01:~$ sudo config interface breakout Ethernet0 1x100G[40G] -f -l -v -y

Running Breakout Mode : 4x25G[10G]
Target Breakout Mode : 1x100G[40G]

Ports to be deleted :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Ports to be added :
 {
    "Ethernet0": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Final list of ports to be added :
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet0']
Merge Default Config for ['Ethernet0']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x100000000186b"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000001897"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000001813"
(empty list or set)
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x100000000183f"
(empty list or set)
Writing in Config DB
Breakout process got successfully completed.
admin@lnos-x1-a-asw01:~$ sudo /usr/bin/nbrshow -4
Address                  HWtype  HWaddress           Flags Mask            Iface
10.1.1.0                 ether   00:e0:ec:3b:d8:35   C                     Ethernet112
10.11.10.12              ether   00:12:01:00:00:01   C                     Vlan100
172.21.47.1              ether   00:ee:ab:9f:d3:d9   C                     eth0
10.11.10.11              ether   00:11:01:00:00:01   C                     Vlan100
10.2.1.0                 ether   00:e0:ec:3b:da:41   C                     Ethernet116

> /usr/bin/nbrshow(128)display()
-> for ent in self.nbrdata:
(Pdb) c
Address      MacAddress         Iface        Vlan
-----------  -----------------  -----------  ------
10.1.1.0     00:e0:ec:3b:d8:35  Ethernet112  -
10.2.1.0     00:e0:ec:3b:da:41  Ethernet116  -
10.11.10.11  00:11:01:00:00:01  -            100
10.11.10.12  00:12:01:00:00:01  Ethernet8    100
172.21.47.1  00:ee:ab:9f:d3:d9  eth0         -
Total number of entries 5
admin@lnos-x1-a-asw01:~$ sudo config interface breakout Ethernet0 4x25G[10G] -f -l -v -y

Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 4x25G[10G]

Ports to be deleted :
 {
    "Ethernet0": "100000"
}
Ports to be added :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet0": "100000"
}
Final list of ports to be added :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet0
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Merge Default Config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000018cf"
(empty list or set)
failed to resize tty, using default size
                                        Writing in Config DB
Breakout process got successfully completed.
admin@lnos-x1-a-asw01:~$ sudo /usr/bin/nbrshow -4
Address                  HWtype  HWaddress           Flags Mask            Iface
10.1.1.0                 ether   00:e0:ec:3b:d8:35   C                     Ethernet112
10.11.10.12              ether   00:12:01:00:00:01   C                     Vlan100
172.21.47.1              ether   00:ee:ab:9f:d3:d9   C                     eth0
10.11.10.11              ether   00:11:01:00:00:01   C                     Vlan100
10.2.1.0                 ether   00:e0:ec:3b:da:41   C                     Ethernet116

> /usr/bin/nbrshow(128)display()
-> for ent in self.nbrdata:
(Pdb) c
Address      MacAddress         Iface        Vlan
-----------  -----------------  -----------  ------
10.1.1.0     00:e0:ec:3b:d8:35  Ethernet112  -
10.2.1.0     00:e0:ec:3b:da:41  Ethernet116  -
10.11.10.11  00:11:01:00:00:01  Ethernet1    100
10.11.10.12  00:12:01:00:00:01  Ethernet8    100
172.21.47.1  00:ee:ab:9f:d3:d9  eth0         -
Total number of entries 5
```

syslog:
--------
```
Mar 19 07:51:49.509484 lnos-x1-a-asw01 NOTICE swss#orchagent: :- doTask: Get port state change notification id:100000000192a status:2
Mar 19 07:51:49.509484 lnos-x1-a-asw01 NOTICE swss#orchagent: :- updatePortOperStatus: Port Ethernet1 oper state set from up to down
Mar 19 07:51:49.510570 lnos-x1-a-asw01 NOTICE swss#orchagent: :- setHostIntfsOperStatus: Set operation status DOWN to host interface Ethernet1
Mar 19 07:51:49.510570 lnos-x1-a-asw01 NOTICE swss#orchagent: :- doTask: Flushing FDB entries for Ethernet1 with bridge port id: 0 as it is DOWN
Mar 19 07:51:49.517479 lnos-x1-a-asw01 NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet0 admin:0 oper:0 addr:00:e0:ec:3c:0a:0a ifindex:1010 master:0
Mar 19 07:51:49.519457 lnos-x1-a-asw01 NOTICE swss#portsyncd: :- onMsg: Publish Ethernet0(ok) to state db
Mar 19 07:51:49.519457 lnos-x1-a-asw01 NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet0 admin:0 oper:0 addr:00:e0:ec:3c:0a:0a ifindex:1010 master:888
```
 

**Details if related**
