### PR TITLE
Fix expected log message string

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1687,7 +1687,7 @@ void PortsOrch::deinitport(string alias, sai_object_id_t port_id)
     string key = getPortFlexCounterTableKey(sai_serialize_object_id(port_id));
     m_flexCounterTable->del(key);
 
-    
+
     SWSS_LOG_NOTICE("De-Initialized port %s", alias.c_str());
 }
 
@@ -2305,13 +2305,13 @@ void PortsOrch::doPortTask(Consumer &consumer)
             if (bridge_port_oid != SAI_NULL_OBJECT_ID)
             {
                 // Bridge port OID is set on a port as long as
-                // port is part of at-least one VLAN. 
-                // Ideally this should be tracked by SAI redis. 
+                // port is part of at-least one VLAN.
+                // Ideally this should be tracked by SAI redis.
                 // Until then, let this snippet be here.
-                SWSS_LOG_NOTICE("Cannot remove port as brodge port OID is present %lx", bridge_port_oid);
+                SWSS_LOG_NOTICE("Cannot remove port as bridge port OID is present %lx", bridge_port_oid);
                 it++;
                 continue;
-            } 
+            }
 
             if (m_portList[alias].m_init)
             {

--- a/tests/test_port_dpb_vlan.py
+++ b/tests/test_port_dpb_vlan.py
@@ -19,7 +19,7 @@ class TestPortDPBVlan(object):
     @pytest.mark.skip()
     '''
     def test_dependency(self, dvs):
-        dpb = DPB() 
+        dpb = DPB()
         dvs.setup_db()
         p = Port(dvs, "Ethernet0")
         p.sync_from_config_db()
@@ -31,7 +31,7 @@ class TestPortDPBVlan(object):
         p.delete_from_config_db()
         #Verify that we are looping on dependency
         time.sleep(2)
-        self.check_syslog(dvs, marker, "doPortTask: Please remove port dependenc(y/ies):VLAN", 1)
+        self.check_syslog(dvs, marker, "Cannot remove port as bridge port OID is present", 1)
         assert(p.exists_in_asic_db() == True)
 
         dvs.remove_vlan_member("100", p.get_name())
@@ -40,7 +40,7 @@ class TestPortDPBVlan(object):
         assert(p.exists_in_asic_db() == False)
 
         #Create the port back and delete the VLAN
-        p.write_to_config_db() 
+        p.write_to_config_db()
         #print "Added port:%s to config DB"%p.get_name()
         p.verify_config_db()
         #print "Config DB verification passed!"
@@ -48,8 +48,8 @@ class TestPortDPBVlan(object):
         #print "Application DB verification passed!"
         p.verify_asic_db()
         #print "ASIC DB verification passed!"
-       
-        dvs.remove_vlan("100") 
+
+        dvs.remove_vlan("100")
 
     '''
     @pytest.mark.skip()
@@ -82,7 +82,7 @@ class TestPortDPBVlan(object):
         port_names = ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"]
         for pname in port_names:
             dvs.create_vlan_member("100", pname)
-        #print "Add %s to VLAN"%port_names            
+        #print "Add %s to VLAN"%port_names
 
         child_ports = []
         for pname in port_names:
@@ -93,15 +93,15 @@ class TestPortDPBVlan(object):
             assert(cp.exists_in_app_db() == False)
             assert(cp.exists_in_asic_db() == True)
             child_ports.append(cp)
-        #print "Deleted %s from config DB and APP DB"%port_names            
+        #print "Deleted %s from config DB and APP DB"%port_names
 
         for cp in child_ports:
             dvs.remove_vlan_member("100", cp.get_name())
             time.sleep(1)
             assert(cp.exists_in_asic_db() == False)
-        #print "Deleted %s from VLAN"%port_names            
+        #print "Deleted %s from VLAN"%port_names
 
-        p.write_to_config_db() 
+        p.write_to_config_db()
         #print "Added port:%s to config DB"%p.get_name()
         p.verify_config_db()
         #print "Config DB verification passed!"
@@ -112,7 +112,7 @@ class TestPortDPBVlan(object):
 
         dvs.remove_vlan("100")
 
-    '''    
+    '''
     @pytest.mark.skip()
     '''
     def test_one_port_multiple_vlan(self, dvs):
@@ -160,10 +160,10 @@ class TestPortDPBVlan(object):
             assert(cp.exists_in_config_db() == False)
             assert(cp.exists_in_app_db() == False)
             assert(cp.exists_in_asic_db() == False)
-        #print "Deleted %s and verified all DBs"%port_names            
+        #print "Deleted %s and verified all DBs"%port_names
 
         #Add back Ethernet0
-        p.write_to_config_db() 
+        p.write_to_config_db()
         p.verify_config_db()
         p.verify_app_db()
         p.verify_asic_db()


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Corrected typo in log message. Updated test script with expected string in syslog.

**Why I did it**

**How I verified it**
Ran VLAN test cases and checked syslog
```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --pdb -s -v --dvsname=vs-vp test_port_dpb_vlan.py
[sudo] password for vapatil:
======================================================================= test session starts ========================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 3 items

test_port_dpb_vlan.py::TestPortDPBVlan::test_dependency remove extra link dummy
remove extra link Vlan100@Bridge
Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f08689e2a08>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f08689e2a08> = <_sre.SRE_Match object at 0x7f08689e2a08>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f086891d390>> ignored
PASSED                                                                                               [ 33%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_one_vlan PASSED                                                                                        [ 66%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_multiple_vlan PASSED                                                                                   [100%]Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f0868a757b0>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f0868a757b0> = <_sre.SRE_Match object at 0x7f0868a757b0>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f086891d750>> ignored


==================================================================== 3 passed in 173.50 seconds ====================================================================
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$
```
**Details if related**
