### PR TITLE
FIX bugs and add VLAN scale test

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -429,6 +429,8 @@ void FdbOrch::flushFDBEntry(sai_object_id_t bridge_port_oid,
     if (SAI_NULL_OBJECT_ID == bridge_port_oid ||
         SAI_NULL_OBJECT_ID == vlan_oid)
     {
+        SWSS_LOG_WARN("Couldn't flush FDB. Bridge port OID: 0x%" PRIx64 " bvid:%" PRIx64 ",",
+                      bridge_port_oid, vlan_oid);
         return;
     }
 

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -417,13 +417,48 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
     }
 }
 
+void FdbOrch::flushFDBEntry(sai_object_id_t bridge_port_oid,
+                            sai_object_id_t vlan_oid)
+{
+    vector<sai_attribute_t>    attrs;
+    sai_attribute_t            attr;
+    sai_status_t               rv = SAI_STATUS_SUCCESS;
+
+    SWSS_LOG_ENTER();
+
+    if (SAI_NULL_OBJECT_ID == bridge_port_oid ||
+        SAI_NULL_OBJECT_ID == vlan_oid)
+    {
+        return;
+    }
+
+    attr.id = SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID;
+    attr.value.oid = bridge_port_oid;
+    attrs.push_back(attr);
+
+    attr.id = SAI_FDB_FLUSH_ATTR_BV_ID;
+    attr.value.oid = vlan_oid;
+    attrs.push_back(attr);
+
+    SWSS_LOG_INFO("Flushing FDB bridge_port_oid: 0x%" PRIx64 ", and bvid_oid:0x%" PRIx64 ".", bridge_port_oid, vlan_oid);
+
+    rv = sai_fdb_api->flush_fdb_entries(gSwitchId, (uint32_t)attrs.size(), attrs.data());
+    if (SAI_STATUS_SUCCESS != rv)
+    {
+        SWSS_LOG_ERROR("Flushing FDB failed. rv:%d", rv);
+    }
+}
+
 void FdbOrch::updateVlanMember(const VlanMemberUpdate& update)
 {
     SWSS_LOG_ENTER();
 
     if (!update.add)
     {
-        return; // we need additions only
+        swss::Port vlan = update.vlan;
+        swss::Port port = update.member;
+        flushFDBEntry(port.m_bridge_port_id, vlan.m_vlan_info.vlan_oid);
+        return;
     }
 
     string port_name = update.member.m_alias;

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -417,8 +417,8 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
     }
 }
 
-void FdbOrch::flushFDBEntry(sai_object_id_t bridge_port_oid,
-                            sai_object_id_t vlan_oid)
+void FdbOrch::flushFDBEntries(sai_object_id_t bridge_port_oid,
+                              sai_object_id_t vlan_oid)
 {
     vector<sai_attribute_t>    attrs;
     sai_attribute_t            attr;
@@ -459,7 +459,7 @@ void FdbOrch::updateVlanMember(const VlanMemberUpdate& update)
     {
         swss::Port vlan = update.vlan;
         swss::Port port = update.member;
-        flushFDBEntry(port.m_bridge_port_id, vlan.m_vlan_info.vlan_oid);
+        flushFDBEntries(port.m_bridge_port_id, vlan.m_vlan_info.vlan_oid);
         return;
     }
 

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -62,8 +62,8 @@ private:
     void updateVlanMember(const VlanMemberUpdate&);
     bool addFdbEntry(const FdbEntry&, const string&, const string&);
     bool removeFdbEntry(const FdbEntry&);
-    void flushFDBEntry(sai_object_id_t bridge_port_oid,
-                       sai_object_id_t vlan_oid);
+    void flushFDBEntries(sai_object_id_t bridge_port_oid,
+                         sai_object_id_t vlan_oid);
 
     bool storeFdbEntryState(const FdbUpdate& update);
 };

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -62,6 +62,8 @@ private:
     void updateVlanMember(const VlanMemberUpdate&);
     bool addFdbEntry(const FdbEntry&, const string&, const string&);
     bool removeFdbEntry(const FdbEntry&);
+    void flushFDBEntry(sai_object_id_t bridge_port_oid,
+                       sai_object_id_t vlan_oid);
 
     bool storeFdbEntryState(const FdbUpdate& update);
 };

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3188,8 +3188,7 @@ bool PortsOrch::removeBridgePort(Port &port)
     }
 
     /* Flush FDB entries pointing to this bridge port */
-    // TODO: Remove all FDB entries associated with this bridge port before
-    //       removing the bridge port itself
+    flushFDBEntries(port.m_bridge_port_id);
 
     /* Remove bridge port */
     status = sai_bridge_api->remove_bridge_port(port.m_bridge_port_id);
@@ -4055,6 +4054,6 @@ void PortsOrch::flushFDBEntries(sai_object_id_t bridge_port_id)
 
     if (rv != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Flush fdb by bridge port id: %" PRIx64 "failed: %d", bridge_port_id, rv);
+        SWSS_LOG_ERROR("Flush fdb by bridge port id: %" PRIx64 " failed: %d", bridge_port_id, rv);
     }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Wrote Scale test for DPB VLAN dependency
Fixed encountered bug:

Bug: During scale testing, even though we remove the port from all VLANS, were unable to delete the port as associated bridge port was still present

Root cause: The bridge port associated with port was NOT deleted because, FDB entries were NOT flushed. Though we are calling flushFDBentries from portsorch when the port goes down, but it wont work if the port is already deleted from VLAN and the bridge_port_id is removed. 

Solution: As per existing code, whenever we add/remove port from VLAN,  portsorch notifies it to fdborch by passing <vlan_oid, port_oid>, but only add was handled and remove was ignored in fdborch. I updated/changed that. Whenever fdborch receives a notification of vlan member removed, I derive bridge_port_oid from port_oid and call flush using <bvid, bridge_port_id>.  

**Why I did it**

**How I verified it**
By running the test case

**Details if related**
```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --pdb -s -v --dvsname=vs-vp test_port_dpb_vlan.py
[sudo] password for vapatil: 
======================================================================= test session starts ========================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 4 items                                                                                                                                                  

test_port_dpb_vlan.py::TestPortDPBVlan::test_dependency remove extra link dummy
PASSED                                                                                               [ 25%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_one_vlan PASSED                                                                                        [ 50%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_multiple_vlan PASSED                                                                                   [ 75%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_all_port_10_vlans PASSED                                                                                        [100%]

==================================================================== 4 passed in 966.91 seconds ====================================================================
```