### PR TITLE
DPB-ACL scale tests

### DIFF
--- a/tests/port_dpb.py
+++ b/tests/port_dpb.py
@@ -221,8 +221,6 @@ class DPB():
             #dvs.runcmd("ip link delete " + cp.get_name())
         #print "Deleted child ports:%s from config DB"%port_names
 
-        #time.sleep(2)
-
         for cp in child_ports:
             assert(cp.exists_in_config_db() == False)
         for cp in child_ports:
@@ -253,7 +251,6 @@ class DPB():
             cp.write_to_config_db()
             child_port_names.append(cp.get_name())
         #print "Added child ports:%s to config DB"%child_port_names
-        time.sleep(6)
 
         for cp in child_ports:
             assert(cp.exists_in_config_db() == True)
@@ -278,7 +275,7 @@ class DPB():
         # TBD, need vs lib to support hostif removal
         #dvs.runcmd("ip link delete " + p.get_name())
         #print "Deleted port:%s from config DB"%port_name
-        time.sleep(6)
+        time.sleep(2)
 
         # Verify port is deleted from all DBs
         assert(p.exists_in_config_db() == False)

--- a/tests/port_dpb.py
+++ b/tests/port_dpb.py
@@ -53,7 +53,7 @@ class Port():
         self._index = index
 
     def set_oid(self, oid = None):
-        self._oid = oid 
+        self._oid = oid
 
     def get_speed(self):
         return self._speed
@@ -154,7 +154,7 @@ class Port():
                                           ("speed", speed_str),
                                           ("index", index_str)])
         self._cfg_db_ptbl.set(self.get_name(), fvs)
-        time.sleep(1)
+        time.sleep(2)
 
     def get_fvs_dict(self, fvs):
         fvs_dict = {}
@@ -217,11 +217,11 @@ class DPB():
 
         for cp in child_ports:
             cp.delete_from_config_db()
-            # TBD, need vs lib to support removing hostif 
+            # TBD, need vs lib to support removing hostif
             #dvs.runcmd("ip link delete " + cp.get_name())
         #print "Deleted child ports:%s from config DB"%port_names
 
-        time.sleep(6)
+        #time.sleep(2)
 
         for cp in child_ports:
             assert(cp.exists_in_config_db() == False)
@@ -235,7 +235,6 @@ class DPB():
         p.port_merge(child_ports)
         p.write_to_config_db()
         #print "Added port:%s to config DB"%p.get_name()
-        time.sleep(2)
 
         p.verify_config_db()
         #print "Config DB verification passed!"
@@ -285,7 +284,7 @@ class DPB():
         assert(p.exists_in_config_db() == False)
         assert(p.exists_in_app_db() == False)
         assert(p.exists_in_asic_db() == False)
-        
+
         self.create_child_ports(dvs, p, num_child_ports)
 
 

--- a/tests/test_port_dpb_acl.py
+++ b/tests/test_port_dpb_acl.py
@@ -8,6 +8,11 @@ import json
 import re
 from port_dpb import DPB
 
+maxPorts = 32
+maxBreakout = 4
+maxRootPorts = maxPorts/maxBreakout
+maxAclTables = 16
+
 @pytest.mark.usefixtures('dpb_setup_fixture')
 class TestPortDPBAcl(object):
 
@@ -25,7 +30,7 @@ class TestPortDPBAcl(object):
         assert len(acl_table_ids) == 1
         dvs.verify_acl_group_num(0)
         acl_group_ids = dvs.get_acl_group_ids()
-        assert len(acl_group_ids) == 0 
+        assert len(acl_group_ids) == 0
 
         bind_ports = ["Ethernet0"]
         fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
@@ -35,7 +40,7 @@ class TestPortDPBAcl(object):
         assert len(acl_table_ids) == 1
         dvs.verify_acl_group_num(1)
         acl_group_ids = dvs.get_acl_group_ids()
-        assert len(acl_group_ids) == 1 
+        assert len(acl_group_ids) == 1
         dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
         dvs.verify_acl_port_binding(bind_ports)
 
@@ -47,7 +52,7 @@ class TestPortDPBAcl(object):
         assert len(acl_table_ids) == 1
         dvs.verify_acl_group_num(0)
         acl_group_ids = dvs.get_acl_group_ids()
-        assert len(acl_group_ids) == 0 
+        assert len(acl_group_ids) == 0
 
     '''
     @pytest.mark.skip()
@@ -116,7 +121,7 @@ class TestPortDPBAcl(object):
 
         # Breakout Ethernet0
         dpb = DPB()
-        dpb.breakout(dvs, "Ethernet0", 4)
+        dpb.breakout(dvs, "Ethernet0", maxBreakout)
         time.sleep(2)
 
         #Update bind list and verify
@@ -163,7 +168,106 @@ class TestPortDPBAcl(object):
         time.sleep(2)
         dvs.verify_acl_group_num(0)
 
+    '''
     @pytest.mark.skip()
+    '''
     def test_one_port_many_acl_tables(self, dvs):
-        #TBD
-        return 
+        dvs.setup_db()
+
+        # Create 4 ACL tables and bind them to Ethernet0
+        bind_ports = ["Ethernet0"]
+        dvs.create_acl_table("test1", "L3", bind_ports)
+        dvs.create_acl_table("test2", "L3", bind_ports)
+        dvs.create_acl_table("test3", "L3", bind_ports)
+        dvs.create_acl_table("test4", "L3", bind_ports)
+
+        acl_table_ids = dvs.get_acl_table_ids()
+        assert len(acl_table_ids) == 4
+        dvs.verify_acl_group_num(1)
+        acl_group_ids = dvs.get_acl_group_ids()
+        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
+        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[1])
+        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[2])
+        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[3])
+        dvs.verify_acl_port_binding(bind_ports)
+
+        # Update bind list and verify
+        bind_ports = []
+        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
+        dvs.update_acl_table("test1", fvs)
+        dvs.update_acl_table("test2", fvs)
+        dvs.update_acl_table("test3", fvs)
+        dvs.update_acl_table("test4", fvs)
+        dvs.verify_acl_group_num(0)
+
+        # Breakout Ethernet0
+        dpb = DPB()
+        dpb.breakout(dvs, "Ethernet0", maxBreakout)
+
+        #Breakin Ethernet0, 1, 2, 3
+        dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
+
+        dvs.remove_acl_table("test1")
+        dvs.remove_acl_table("test2")
+        dvs.remove_acl_table("test3")
+        dvs.remove_acl_table("test4")
+
+    '''
+    @pytest.mark.skip()
+    '''
+    def test_many_ports_many_acl_tables(self, dvs):
+        dvs.setup_db()
+
+        # Prepare ACL table names
+        aclTableNames = []
+        for i in range(maxAclTables):
+            aclTableNames.append("aclTable" + str(i+1))
+
+        # Prepare all port names
+        portNames = []
+        for i in range(maxPorts):
+            portNames.append("Ethernet" + str(i))
+
+        # Prepare root port names
+        rootPortNames = []
+        for i in range(0, maxPorts, maxBreakout):
+            rootPortNames.append("Ethernet" + str(i))
+
+        # Create ACL tables and bind root ports
+        for aclTable in aclTableNames:
+            dvs.create_acl_table(aclTable, "L3", rootPortNames)
+        dvs.verify_acl_group_num(maxRootPorts)
+
+        # Remove the dependency on all root ports by
+        # unbinding them from all ACL tables.
+        bind_ports = []
+        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
+        for aclTable in aclTableNames:
+            dvs.update_acl_table(aclTable, fvs)
+        dvs.verify_acl_group_num(0)
+
+        # Breakout all root ports
+        dpb = DPB()
+        for pName in rootPortNames:
+            #print "Breaking out %s"%pName
+            dpb.breakout(dvs, pName, maxBreakout)
+
+        # Add all ports to aclTable1
+        fvs = swsscommon.FieldValuePairs([("ports", ",".join(portNames))])
+        dvs.update_acl_table(aclTableNames[0], fvs)
+        dvs.verify_acl_group_num(maxPorts)
+
+        # Remove all ports from aclTable1
+        bind_ports = []
+        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
+        dvs.update_acl_table(aclTableNames[0], fvs)
+        dvs.verify_acl_group_num(0)
+
+        # Breakin all ports
+        for i in range(0, maxPorts, maxBreakout):
+            #print "Breaking in %s"%portNames[i:i+maxBreakout]
+            dpb.breakin(dvs, portNames[i:i+maxBreakout])
+
+        for aclTable in aclTableNames:
+            dvs.remove_acl_table(aclTable)
+        dvs.verify_acl_group_num(0)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Wrote scale test(s) for ACL dependency handling in DPB

**Why I did it**
To catch any scale issues

**How I verified it**
Ran tests

**Details if related**
```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --pdb -s -v --dvsname=vs-vp test_port_dpb_acl.py
======================================================================= test session starts ========================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 5 items

test_port_dpb_acl.py::TestPortDPBAcl::test_acl_table_empty_port_list remove extra link dummy
Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f3062bcde40>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f3062bcde40> = <_sre.SRE_Match object at 0x7f3062bcde40>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f3062bcbf10>> ignored
PASSED                                                                                  [ 20%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_two_acl_tables PASSED                                                                                    [ 40%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_acl_table_many_ports PASSED                                                                                   [ 60%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_many_acl_tables PASSED                                                                                   [ 80%]
test_port_dpb_acl.py::TestPortDPBAcl::test_all_ports_two_acl_tables PASSED                                                                                   [100%]Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f3062caa648>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f3062caa648> = <_sre.SRE_Match object at 0x7f3062caa648>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f3062c15f10>> ignored


=================================================================== 5 passed in 1080.87 seconds ====================================================================
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$
```