### PR TITLE
Remove queue and PG flex counter stats when port is deleted.

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -56,7 +56,7 @@ IntfsOrch::IntfsOrch(DBConnector *db, string tableName, VRFOrch *vrf_orch) :
 {
     SWSS_LOG_ENTER();
 
-    /* Initialize DB connectors */ 
+    /* Initialize DB connectors */
     m_counter_db = shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
     m_flex_db = shared_ptr<DBConnector>(new DBConnector("FLEX_COUNTER_DB", 0));
     m_asic_db = shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -77,6 +77,8 @@ public:
     bool                m_autoneg = false;
     bool                m_admin_state_up = false;
     bool                m_init = false;
+    bool                m_isPortQueueMapGenerated = false;
+    bool                m_isPortPriorityGroupMapGenerated = false;
     sai_object_id_t     m_port_id = 0;
     sai_port_fec_mode_t m_fec_mode = SAI_PORT_FEC_MODE_NONE;
     VlanInfo            m_vlan_info;
@@ -112,7 +114,6 @@ public:
      */
     std::vector<bool> m_queue_lock;
     std::vector<bool> m_priority_group_lock;
-
 };
 
 }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -194,7 +194,7 @@ private:
     bool addPort(const set<int> &lane_set, uint32_t speed, int an=0, string fec="");
     bool removePort(sai_object_id_t port_id);
     bool initPort(const string &alias, const set<int> &lane_set);
-    void deinitport(const Port&);
+    void deinitport(Port&);
     void flush();
 
     bool setPortAdminStatus(sai_object_id_t id, bool up);
@@ -216,12 +216,12 @@ private:
     bool getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uint8_t &index);
 
     bool m_isQueueMapGenerated = false;
-    void generateQueueMapPerPort(const Port& port);
-    void destroyQueueMapPerPort(const Port& port);
+    void generateQueueMapPerPort(Port& port);
+    void destroyQueueMapPerPort(Port& port);
 
     bool m_isPriorityGroupMapGenerated = false;
-    void generatePriorityGroupMapPerPort(const Port& port);
-    void destroyPriorityGroupMapPerPort(const Port& port);
+    void generatePriorityGroupMapPerPort(Port& port);
+    void destroyPriorityGroupMapPerPort(Port& port);
 
     bool setPortAutoNeg(sai_object_id_t id, int an);
     bool setPortFecMode(sai_object_id_t id, int fec);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -194,7 +194,7 @@ private:
     bool addPort(const set<int> &lane_set, uint32_t speed, int an=0, string fec="");
     bool removePort(sai_object_id_t port_id);
     bool initPort(const string &alias, const set<int> &lane_set);
-    void deinitport(string alias, sai_object_id_t port_id);
+    void deinitport(const Port&);
     void flush();
 
     bool setPortAdminStatus(sai_object_id_t id, bool up);
@@ -217,9 +217,11 @@ private:
 
     bool m_isQueueMapGenerated = false;
     void generateQueueMapPerPort(const Port& port);
+    void destroyQueueMapPerPort(const Port& port);
 
     bool m_isPriorityGroupMapGenerated = false;
     void generatePriorityGroupMapPerPort(const Port& port);
+    void destroyPriorityGroupMapPerPort(const Port& port);
 
     bool setPortAutoNeg(sai_object_id_t id, int an);
     bool setPortFecMode(sai_object_id_t id, int fec);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Cleared flex counter stats when port is deleted.
**Why I did it**
When ports are created, and flex counter is eanbled, for each port, we do the following:
1. Add flex counter stat to flex counter DB for each queue(including watermark)
2. Add flex counter stat to flex counter DB for each PG.
3. Add port to mcCounterMap and PFCCounterMap in CounterCheckOrch. Note that mcCounter are per queue and PFC counters are per priority. They key for the elements in these maps is port OID. and periodically, they walk through these maps and populate the counters list for each port.

When port is deleted, syslog error was complaining about the presence of port in mcCounterMap and PFCCounterMap is in-valid.

Solution:
As a quick fix, when port is deleted we could have just removed it from the above two maps. But to provide the complete fix, we are also going to cleanup the queue and PG counter list in flex_counter DB. This done because, when the port itself is deleted, these entries are stale. 

But the thing to note is, whenever we delete and re-create a port, the OIDs of queues and PGs remain the same. Note that queue OIDs and PG OIDS are created in SAI REDIS library or in hardware. They are NOT the objects created by orchagent. Orchagent just reads these OIDs on port creation.

One more thing to note is, when we perform dynamic port breakout, root port always gets deleted and added back. But non-root ports may or may NOT get added back. So, we can further optimize this code by NOT deleting the queue and PG OIDS for root ports. Because when the port is deleted and re-created the queue OIDs and PG OIDs remain the same. 


**How I verified it**
Executed DPB command from 4x --> 1x and reproduced the issue. After the fix, verified that the error message is no longer present.

**Details if related**
Before FIx:

=========
```
admin@lnos-x1-a-asw01:~$ sudo config interface breakout Ethernet0 1x100G[40G] -f -l -y

Running Breakout Mode : 4x25G[10G]
Target Breakout Mode : 1x100G[40G]

Ports to be deleted :

{ "Ethernet2": "25000", "Ethernet3": "25000", "Ethernet0": "25000", "Ethernet1": "25000" }
Ports to be added :

{ "Ethernet0": "100000" }
After running Logic to limit the impact

Final list of ports to be deleted :

{ "Ethernet2": "25000", "Ethernet3": "25000", "Ethernet0": "25000", "Ethernet1": "25000" }
Final list of ports to be added :

{ "Ethernet0": "100000" }
Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet0']
Merge Default Config for ['Ethernet0']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
admin@lnos-x1-a-asw01:~$ date
Thu Apr 9 17:15:27 UTC 2020
admin@lnos-x1-a-asw01:~$ tail -f /var/log/syslog
Apr 9 17:15:20.758673 lnos-x1-a-asw01 INFO kernel: [3091390.947880] Bridge: port 2(Ethernet0) entered disabled state
Apr 9 17:15:20.759251 lnos-x1-a-asw01 NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet0 admin:1 oper:0 addr:00:e0:ec:3c:0a:0a ifindex:1969 master:0
Apr 9 17:15:20.760563 lnos-x1-a-asw01 NOTICE swss#portsyncd: :- onMsg: Publish Ethernet0(ok) to state db
Apr 9 17:15:20.760600 lnos-x1-a-asw01 INFO kernel: [3091390.949032] device Ethernet0 entered promiscuous mode
Apr 9 17:15:20.761025 lnos-x1-a-asw01 NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet0 admin:1 oper:0 addr:00:e0:ec:3c:0a:0a ifindex:1969 master:1838
Apr 9 17:15:20.768098 lnos-x1-a-asw01 NOTICE swss#orchagent: :- setHostIntfsStripTag: Set SAI_HOSTIF_VLAN_TAG_KEEP to host interface: Ethernet0
Apr 9 17:15:20.768326 lnos-x1-a-asw01 NOTICE swss#orchagent: :- addBridgePort: Add bridge port Ethernet0 to default 1Q bridge
Apr 9 17:15:20.768650 lnos-x1-a-asw01 NOTICE swss#orchagent: :- addVlanMember: Add member Ethernet0 to VLAN Vlan100 vid:100 pid1000000001aab
Apr 9 17:15:20.768789 lnos-x1-a-asw01 NOTICE swss#orchagent: :- setPortPvid: Set pvid 100 to port: Ethernet0
Apr 9 17:15:20.783543 lnos-x1-a-asw01 NOTICE swss#orchagent: :- addVlanMember: Add member Ethernet0 to VLAN Vlan777 vid:777 pid1000000001aab
Apr 9 17:15:39.912238 lnos-x1-a-asw01 ERR swss#orchagent: :- mcCounterCheck: Invalid port oid 0x1000000000e86
Apr 9 17:15:39.912396 lnos-x1-a-asw01 ERR swss#orchagent: :- mcCounterCheck: Invalid port oid 0x1000000000eaf
Apr 9 17:15:39.912713 lnos-x1-a-asw01 ERR swss#orchagent: :- mcCounterCheck: Invalid port oid 0x1000000000ed8
Apr 9 17:15:39.912926 lnos-x1-a-asw01 ERR swss#orchagent: :- mcCounterCheck: Invalid port oid 0x1000000000f01
Apr 9 17:15:40.078250 lnos-x1-a-asw01 ERR swss#orchagent: :- pfcFrameCounterCheck: Invalid port oid 0x1000000000e86
Apr 9 17:15:40.078642 lnos-x1-a-asw01 ERR swss#orchagent: :- pfcFrameCounterCheck: Invalid port oid 0x1000000000eaf
Apr 9 17:15:40.078901 lnos-x1-a-asw01 ERR swss#orchagent: :- pfcFrameCounterCheck: Invalid port oid 0x1000000000ed8
Apr 9 17:15:40.079297 lnos-x1-a-asw01 ERR swss#orchagent: :- pfcFrameCounterCheck: Invalid port oid 0x1000000000f01
^C
admin@lnos-x1-a-asw01:~$
```
 

  

After Fix:

=======
```

admin@lnos-x1-a-asw01:~$ sudo config interface breakout Ethernet0 1x100G[40G] -f -l -y

Running Breakout Mode : 4x25G[10G]
Target Breakout Mode : 1x100G[40G]

Ports to be deleted :

{ "Ethernet2": "25000", "Ethernet3": "25000", "Ethernet0": "25000", "Ethernet1": "25000" }
Ports to be added :

{ "Ethernet0": "100000" }
After running Logic to limit the impact

Final list of ports to be deleted :

{ "Ethernet2": "25000", "Ethernet3": "25000", "Ethernet0": "25000", "Ethernet1": "25000" }
Final list of ports to be added :

{ "Ethernet0": "100000" }
Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet0']
Merge Default Config for ['Ethernet0']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
admin@lnos-x1-a-asw01:~$ date
Thu Apr 9 17:28:03 UTC 2020
admin@lnos-x1-a-asw01:~$ tail -f /var/log/syslog
Apr 9 17:28:01.240620 lnos-x1-a-asw01 INFO kernel: [3092151.398995] Bridge: port 2(Ethernet0) entered disabled state
Apr 9 17:28:01.241909 lnos-x1-a-asw01 NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet0 admin:1 oper:0 addr:00:e0:ec:3c:0a:0a ifindex:2086 master:0
Apr 9 17:28:01.241909 lnos-x1-a-asw01 NOTICE swss#portsyncd: :- onMsg: Publish Ethernet0(ok) to state db
Apr 9 17:28:01.243234 lnos-x1-a-asw01 NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet0 admin:1 oper:0 addr:00:e0:ec:3c:0a:0a ifindex:2086 master:1970
Apr 9 17:28:01.244572 lnos-x1-a-asw01 INFO kernel: [3092151.400965] device Ethernet0 entered promiscuous mode
Apr 9 17:28:01.256735 lnos-x1-a-asw01 NOTICE swss#orchagent: :- setHostIntfsStripTag: Set SAI_HOSTIF_VLAN_TAG_KEEP to host interface: Ethernet0
Apr 9 17:28:01.256735 lnos-x1-a-asw01 NOTICE swss#orchagent: :- addBridgePort: Add bridge port Ethernet0 to default 1Q bridge
Apr 9 17:28:01.259026 lnos-x1-a-asw01 NOTICE swss#orchagent: :- addVlanMember: Add member Ethernet0 to VLAN Vlan100 vid:100 pid10000000017e2
Apr 9 17:28:01.259026 lnos-x1-a-asw01 NOTICE swss#orchagent: :- setPortPvid: Set pvid 100 to port: Ethernet0
Apr 9 17:28:01.274068 lnos-x1-a-asw01 NOTICE swss#orchagent: :- addVlanMember: Add member Ethernet0 to VLAN Vlan777 vid:777 pid10000000017e2
```