### PR TITLE
Revert "Temporarily disable multiple ports breakout"

### DIFF
--- a/tests/test_port_dpb.py
+++ b/tests/test_port_dpb.py
@@ -61,7 +61,9 @@ class TestPortDPB(object):
         dpb.change_speed_and_verify(dvs, ["Ethernet0"], 40000)
         #print "**** 1X100G --> 1X40G passed ****"
 
-    @pytest.mark.skip(reason="test stability issue: Azure/sonic-swss#1222")
+    '''
+    @pytest.mark.skip()
+    '''
     def test_port_breakout_multiple(self, dvs):
         dpb = DPB()
         port_names = ["Ethernet0", "Ethernet12", "Ethernet64", "Ethernet112"]
@@ -72,7 +74,9 @@ class TestPortDPB(object):
         dpb.breakin(dvs, ["Ethernet64", "Ethernet65", "Ethernet66", "Ethernet67"])
         dpb.breakin(dvs, ["Ethernet112", "Ethernet113", "Ethernet114", "Ethernet115"])
 
-    @pytest.mark.skip(reason="test stability issue: Azure/sonic-swss#1222")
+    '''
+    @pytest.mark.skip()
+    '''
     def test_port_breakout_all(self, dvs):
         dpb = DPB()
         port_names = []


### PR DESCRIPTION
This reverts commit 1872b04990e7cf489ac3678fa80078fe2706e182.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Revert commit to disbale dpb test cases
**Why I did it**

**How I verified it**

**Details if related**
