### PR TITLE
Copied dvslib directory from master

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,9 @@ import subprocess
 from datetime import datetime
 from swsscommon import swsscommon
 
+from dvslib import dvs_database as dvs_db
+from dvslib import dvs_acl
+
 def ensure_system(cmd):
     rc = os.WEXITSTATUS(os.system(cmd))
     if rc:
@@ -144,6 +147,13 @@ class VirtualServer(object):
         return subprocess.check_output("ip netns exec %s %s" % (self.nsname, cmd), shell=True)
 
 class DockerVirtualSwitch(object):
+    APP_DB_ID = 0
+    ASIC_DB_ID = 1
+    COUNTERS_DB_ID = 2
+    CONFIG_DB_ID = 4
+    FLEX_COUNTER_DB_ID = 5
+    STATE_DB_ID = 6
+
     def __init__(self, name=None, imgname=None, keeptb=False, fakeplatform=None):
         self.basicd = ['redis-server',
                        'rsyslogd']
@@ -225,6 +235,14 @@ class DockerVirtualSwitch(object):
 
         self.redis_sock = self.mount + '/' + "redis.sock"
         self.check_ctn_status_and_db_connect()
+
+        # DB wrappers are declared here, lazy-loaded in the tests
+        self.app_db = None
+        self.asic_db = None
+        self.counters_db = None
+        self.config_db = None
+        self.flex_db = None
+        self.state_db = None
 
     def destroy(self):
         if self.appldb:
@@ -941,6 +959,49 @@ class DockerVirtualSwitch(object):
         atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP")
         acl_table_groups = atbl.getKeys()
         assert len(acl_table_groups) == len(bind_ports)
+
+    def get_app_db(self):
+        if not self.app_db:
+            self.app_db = dvs_db.DVSDatabase(self.APP_DB_ID, self.redis_sock)
+
+        return self.app_db
+
+    def get_asic_db(self):
+        if not self.asic_db:
+            db = dvs_db.DVSDatabase(self.ASIC_DB_ID, self.redis_sock)
+            db.default_acl_tables = self.asicdb.default_acl_tables
+            db.default_acl_entries = self.asicdb.default_acl_entries
+            db.port_name_map = self.asicdb.portnamemap
+            db.default_vlan_id = self.asicdb.default_vlan_id
+            db.port_to_id_map = self.asicdb.portoidmap
+            db.hostif_name_map = self.asicdb.hostifnamemap
+            self.asic_db = db
+
+        return self.asic_db
+
+    def get_counters_db(self):
+        if not self.counters_db:
+            self.counters_db = dvs_db.DVSDatabase(self.COUNTERS_DB_ID, self.redis_sock)
+
+        return self.counters_db
+
+    def get_config_db(self):
+        if not self.config_db:
+            self.config_db = dvs_db.DVSDatabase(self.CONFIG_DB_ID, self.redis_sock)
+
+        return self.config_db
+
+    def get_flex_db(self):
+        if not self.flex_db:
+            self.flex_db = dvs_db.DVSDatabase(self.FLEX_COUNTER_DB_ID, self.redis_sock)
+
+        return self.flex_db
+
+    def get_state_db(self):
+        if not self.state_db:
+            self.state_db = dvs_db.DVSDatabase(self.STATE_DB_ID, self.redis_sock)
+
+        return self.state_db
 
     def change_port_breakout_mode(self, intf_name, target_mode):
         cmd = "config interface breakout %s %s -y"%(intf_name, target_mode)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1003,6 +1003,14 @@ class DockerVirtualSwitch(object):
 
         return self.state_db
 
+    def get_dvs_acl(self):
+        if not self.dvs_acl:
+            self.dvs_acl = dvs_acl.DVSAcl(self.get_asic_db(),
+                                          self.get_config_db(),
+                                          self.get_state_db(),
+                                          self.get_counters_db())
+        return self.dvs_acl
+
     def change_port_breakout_mode(self, intf_name, target_mode):
         cmd = "config interface breakout %s %s -y"%(intf_name, target_mode)
         self.runcmd(cmd)
@@ -1035,6 +1043,13 @@ def testlog(request, dvs):
     dvs.runcmd("logger === start test %s ===" % request.node.name)
     yield testlog
     dvs.runcmd("logger === finish test %s ===" % request.node.name)
+
+@pytest.yield_fixture(scope="class")
+def dvs_acl_manager(request, dvs):
+    request.cls.dvs_acl = dvs_acl.DVSAcl(dvs.get_asic_db(),
+                                         dvs.get_config_db(),
+                                         dvs.get_state_db(),
+                                         dvs.get_counters_db())
 
 ##################### DPB fixtures ###########################################
 @pytest.yield_fixture(scope="module")

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -1,0 +1,231 @@
+class DVSAcl(object):
+    def __init__(self, adb, cdb, sdb, cntrdb):
+        self.asic_db = adb
+        self.config_db = cdb
+        self.state_db = sdb
+        self.counters_db = cntrdb
+
+    def create_acl_table(self, table_name, table_type, ports, stage=None):
+        table_attrs = {
+            "policy_desc": "DVS acl table test",
+            "type": table_type,
+            "ports": ",".join(ports)
+        }
+
+        if stage:
+            table_attrs["stage"] = stage
+
+        self.config_db.create_entry("ACL_TABLE", table_name, table_attrs)
+
+    def update_acl_table(self, acl_table_name, ports):
+        table_attrs = {
+            "ports": ",".join(ports)
+        }
+        self.config_db.update_entry("ACL_TABLE", acl_table_name, table_attrs)
+
+    def remove_acl_table(self, table_name):
+        self.config_db.delete_entry("ACL_TABLE", table_name)
+
+    def get_acl_table_group_ids(self, expt):
+        acl_table_groups = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", expt)
+        return acl_table_groups
+
+    def get_acl_table_ids(self, expt=1):
+        num_keys = len(self.asic_db.default_acl_tables) + expt
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
+        for k in self.asic_db.default_acl_tables:
+            assert k in keys
+
+        acl_tables = [k for k in keys if k not in self.asic_db.default_acl_tables]
+
+        return acl_tables
+
+    def get_acl_table_id(self):
+        acl_tables = self.get_acl_table_ids()
+        return acl_tables[0]
+
+    def verify_acl_table_count(self, expt):
+        num_keys = len(self.asic_db.default_acl_tables) + expt
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
+        for k in self.asic_db.default_acl_tables:
+            assert k in keys
+
+        acl_tables = [k for k in keys if k not in self.asic_db.default_acl_tables]
+
+        assert len(acl_tables) == expt
+
+    def verify_acl_group_num(self, expt):
+        acl_table_groups = self.get_acl_table_group_ids(expt)
+
+        for group in acl_table_groups:
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", group)
+            for k, v in fvs.items():
+                if k == "SAI_ACL_TABLE_GROUP_ATTR_ACL_STAGE":
+                    assert v == "SAI_ACL_STAGE_INGRESS"
+                elif k == "SAI_ACL_TABLE_GROUP_ATTR_ACL_BIND_POINT_TYPE_LIST":
+                    assert v == "1:SAI_ACL_BIND_POINT_TYPE_PORT"
+                elif k == "SAI_ACL_TABLE_GROUP_ATTR_TYPE":
+                    assert v == "SAI_ACL_TABLE_GROUP_TYPE_PARALLEL"
+                else:
+                    assert False
+
+    def verify_acl_table_group_member(self, acl_table_group_id, acl_table_id):
+        self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", acl_table_group_id)
+        self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", acl_table_id)
+        members = self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER")
+        for m in members:
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", m)
+            fvs = dict(fvs)
+            if (fvs.pop("SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_GROUP_ID") == acl_table_group_id and
+                    fvs.pop("SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_ID") == acl_table_id) :
+                return True
+        assert False
+
+    def verify_acl_group_member(self, acl_group_ids, acl_table_id):
+        members = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", len(acl_group_ids))
+
+        member_groups = []
+        for member in members:
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", member)
+            for k, v in fvs.items():
+                if k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_GROUP_ID":
+                    assert v in acl_group_ids
+                    member_groups.append(v)
+                elif k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_ID":
+                    assert v == acl_table_id
+                elif k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY":
+                    assert True
+                else:
+                    assert False
+
+        assert set(member_groups) == set(acl_group_ids)
+
+    def verify_acl_table_ports_binding(self, ports, acl_table_id):
+        for p in ports:
+            # TBD: Introduce new API in dvs_databse.py to read by field
+            fvs = self.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")
+            fvs = dict(fvs)
+            port_oid = fvs.pop(p)
+            #port_oid = self.counters_db.hget_entry("COUNTERS_PORT_NAME_MAP", "", p)
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+            fvs = dict(fvs)
+            acl_table_group_id = fvs.pop("SAI_PORT_ATTR_INGRESS_ACL")
+            self.verify_acl_table_group_member(acl_table_group_id, acl_table_id)
+
+    def verify_acl_port_binding(self, bind_ports):
+        acl_table_groups = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", len(bind_ports))
+
+        port_groups = []
+        for port in [self.asic_db.port_name_map[p] for p in bind_ports]:
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port)
+            acl_table_group = fvs.pop("SAI_PORT_ATTR_INGRESS_ACL", None)
+            assert acl_table_group in acl_table_groups
+            port_groups.append(acl_table_group)
+
+        assert len(port_groups) == len(bind_ports)
+        assert set(port_groups) == set(acl_table_groups)
+
+    def create_acl_rule(self, table_name, rule_name, qualifiers, action="FORWARD", priority="2020"):
+        fvs = {
+            "priority": priority,
+            "PACKET_ACTION": action
+        }
+
+        for k, v in qualifiers.items():
+            fvs[k] = v
+
+        self.config_db.create_entry("ACL_RULE", "{}|{}".format(table_name, rule_name), fvs)
+
+    def remove_acl_rule(self, table_name, rule_name):
+        self.config_db.delete_entry("ACL_RULE", "{}|{}".format(table_name, rule_name))
+
+    def get_acl_rule_id(self):
+        num_keys = len(self.asic_db.default_acl_entries) + 1
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
+
+        acl_entries = [k for k in keys if k not in self.asic_db.default_acl_entries]
+        return acl_entries[0]
+
+    def verify_no_acl_rules(self):
+        num_keys = len(self.asic_db.default_acl_entries)
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
+        assert set(keys) == set(self.asic_db.default_acl_entries)
+
+    def verify_acl_rule(self, qualifiers, action="FORWARD", priority="2020"):
+        acl_rule_id = self.get_acl_rule_id()
+
+        fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
+        self._check_acl_entry(fvs, qualifiers, action, priority)
+
+    def verify_acl_rule_set(self, priorities, in_actions, expected):
+        num_keys = len(self.asic_db.default_acl_entries) + len(priorities)
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
+
+        acl_entries = [k for k in keys if k not in self.asic_db.default_acl_entries]
+        for entry in acl_entries:
+            rule = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", entry)
+            priority = rule.get("SAI_ACL_ENTRY_ATTR_PRIORITY", None)
+            assert priority in priorities
+            self._check_acl_entry(rule, expected[priority],
+                                  action=in_actions[priority], priority=priority)
+
+    def _check_acl_entry(self, entry, qualifiers, action, priority):
+        acl_table_id = self.get_acl_table_id()
+
+        for k, v in entry.items():
+            if k == "SAI_ACL_ENTRY_ATTR_TABLE_ID":
+                assert v == acl_table_id
+            elif k == "SAI_ACL_ENTRY_ATTR_ADMIN_STATE":
+                assert v == "true"
+            elif k == "SAI_ACL_ENTRY_ATTR_PRIORITY":
+                assert v == priority
+            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_COUNTER":
+                assert True
+            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION":
+                if action == "FORWARD":
+                    assert v == "SAI_PACKET_ACTION_FORWARD"
+                elif action == "DROP":
+                    assert v == "SAI_PACKET_ACTION_DROP"
+                else:
+                    assert False
+            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT":
+                if "REDIRECT" not in action:
+                    assert False
+            elif k in qualifiers:
+                assert qualifiers[k](v)
+            else:
+                assert False
+
+    def get_simple_qualifier_comparator(self, expected_qualifier):
+        def _match_qualifier(sai_qualifier):
+            return expected_qualifier == sai_qualifier
+
+        return _match_qualifier
+
+    def get_port_list_comparator(self, expected_ports):
+        def _match_port_list(sai_port_list):
+            if not sai_port_list.startswith("{}:".format(len(expected_ports))):
+                return False
+            for port in expected_ports:
+                if self.asic_db.port_name_map[port] not in sai_port_list:
+                    return False
+
+            return True
+
+        return _match_port_list
+
+    def get_acl_range_comparator(self, expected_type, expected_ports):
+        def _match_acl_range(sai_acl_range):
+            range_id = sai_acl_range.split(":", 1)[1]
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_RANGE", range_id)
+            for k, v in fvs.items():
+                if k == "SAI_ACL_RANGE_ATTR_TYPE" and v == expected_type:
+                    continue
+                elif k == "SAI_ACL_RANGE_ATTR_LIMIT" and v == expected_ports:
+                    continue
+                else:
+                    return False
+
+            return True
+
+        return _match_acl_range

--- a/tests/dvslib/dvs_common.py
+++ b/tests/dvslib/dvs_common.py
@@ -1,0 +1,62 @@
+"""
+    dvs_common contains common infrastructure for writing tests for the
+    virtual switch.
+"""
+
+import collections
+import time
+
+_PollingConfig = collections.namedtuple('PollingConfig', 'polling_interval timeout strict')
+
+class PollingConfig(_PollingConfig):
+    """
+        PollingConfig provides parameters that are used to control the behavior
+        for polling functions.
+
+        Params:
+            polling_interval (int): How often to poll, in seconds.
+            timeout (int): The maximum amount of time to wait, in seconds.
+            strict (bool): If the strict flag is set, reaching the timeout
+                will cause tests to fail (e.g. assert False)
+    """
+
+    pass
+
+def wait_for_result(polling_function, polling_config):
+    """
+        wait_for_result will periodically run `polling_function`
+        using the parameters described in `polling_config` and return the
+        output of the polling function.
+
+        Args:
+            polling_config (PollingConfig): The parameters to use to poll
+                the db.
+            polling_function (Callable[[], (bool, Any)]): The function being
+                polled. The function takes no arguments and must return a
+                status which indicates if the function was succesful or
+                not, as well as some return value.
+
+        Returns:
+            (bool, Any): If the polling function succeeds, then this method
+            will return True and the output of the polling function. If it
+            does not succeed within the provided timeout, it will return False
+            and whatever the output of the polling function was on the final
+            attempt.
+    """
+    if polling_config.polling_interval == 0:
+        iterations = 1
+    else:
+        iterations = int(polling_config.timeout // polling_config.polling_interval) + 1
+
+    for _ in range(iterations):
+        status, result = polling_function()
+
+        if status:
+            return (True, result)
+
+        time.sleep(polling_config.polling_interval)
+
+    if polling_config.strict:
+        assert False, "Operation timed out after {}s".format(polling_config.timeout)
+
+    return (False, result)

--- a/tests/dvslib/dvs_database.py
+++ b/tests/dvslib/dvs_database.py
@@ -1,0 +1,363 @@
+"""
+    dvs_database contains utilities for interacting with redis when writing
+    tests for the virtual switch.
+"""
+from swsscommon import swsscommon
+from dvslib.dvs_common import wait_for_result, PollingConfig
+
+
+class DVSDatabase(object):
+    """
+        DVSDatabase provides access to redis databases on the virtual switch.
+
+        By default, database operations are configured to use
+        `DEFAULT_POLLING_CONFIG`. Users can specify their own PollingConfig,
+        but this shouldn't typically be necessary.
+    """
+    DEFAULT_POLLING_CONFIG = PollingConfig(polling_interval=0.01, timeout=5, strict=True)
+
+    def __init__(self, db_id, connector):
+        """
+            Initializes a DVSDatabase instance.
+
+            Args:
+                db_id (int): The integer ID used to identify the given database
+                    instance in redis.
+                connector (str): The I/O connection used to communicate with
+                    redis (e.g. unix socket, tcp socket, etc.).
+        """
+
+        self.db_connection = swsscommon.DBConnector(db_id, connector, 0)
+
+    def create_entry(self, table_name, key, entry):
+        """
+            Adds the mapping {`key` -> `entry`} to the specified table.
+
+            Args:
+                table_name (str): The name of the table to add the entry to.
+                key (str): The key that maps to the entry.
+                entry (Dict[str, str]): A set of key-value pairs to be stored.
+        """
+
+        table = swsscommon.Table(self.db_connection, table_name)
+        formatted_entry = swsscommon.FieldValuePairs(entry.items())
+        table.set(key, formatted_entry)
+
+    def update_entry(self, table_name, key, entry):
+        """
+            Updates entries of an existing key in the specified table.
+
+            Args:
+                table_name (str): The name of the table.
+                key (str): The key that needs to be updated.
+                entry (Dict[str, str]): A set of key-value pairs to be updated.
+        """
+
+        table = swsscommon.Table(self.db_connection, table_name)
+        formatted_entry = swsscommon.FieldValuePairs(entry.items())
+        table.set(key, formatted_entry)
+
+    def get_entry(self, table_name, key):
+        """
+            Gets the entry stored at `key` in the specified table.
+
+            Args:
+                table_name (str): The name of the table where the entry is
+                    stored.
+                key (str): The key that maps to the entry being retrieved.
+
+            Returns:
+                Dict[str, str]: The entry stored at `key`. If no entry is found,
+                then an empty Dict will be returned.
+        """
+
+        table = swsscommon.Table(self.db_connection, table_name)
+        (status, fv_pairs) = table.get(key)
+
+        if not status:
+            return {}
+
+        return dict(fv_pairs)
+
+    def delete_entry(self, table_name, key):
+        """
+            Removes the entry stored at `key` in the specified table.
+
+            Args:
+                table_name (str): The name of the table where the entry is
+                    being removed.
+                key (str): The key that maps to the entry being removed.
+        """
+
+        table = swsscommon.Table(self.db_connection, table_name)
+        table._del(key)  # pylint: disable=protected-access
+
+    def get_keys(self, table_name):
+        """
+            Gets all of the keys stored in the specified table.
+
+            Args:
+                table_name (str): The name of the table from which to fetch
+                the keys.
+
+            Returns:
+                List[str]: The keys stored in the table. If no keys are found,
+                then an empty List will be returned.
+        """
+
+        table = swsscommon.Table(self.db_connection, table_name)
+        keys = table.getKeys()
+
+        return keys if keys else []
+
+    def wait_for_entry(self, table_name, key,
+                       polling_config=DEFAULT_POLLING_CONFIG):
+        """
+            Gets the entry stored at `key` in the specified table. This method
+            will wait for the entry to exist.
+
+            Args:
+                table_name (str): The name of the table where the entry is
+                    stored.
+                key (str): The key that maps to the entry being retrieved.
+                polling_config (PollingConfig): The parameters to use to poll
+                    the db.
+
+            Returns:
+                Dict[str, str]: The entry stored at `key`. If no entry is found,
+                then an empty Dict will be returned.
+
+        """
+
+        def _access_function():
+            fv_pairs = self.get_entry(table_name, key)
+            return (bool(fv_pairs), fv_pairs)
+
+        status, result = wait_for_result(_access_function,
+                                         self._disable_strict_polling(polling_config))
+
+        if not status:
+            assert not polling_config.strict, \
+                "Entry not found: key=\"{}\", table=\"{}\"".format(key, table_name)
+
+        return result
+
+    def wait_for_field_match(self,
+                             table_name,
+                             key,
+                             expected_fields,
+                             polling_config=DEFAULT_POLLING_CONFIG):
+        """
+            Checks if the provided fields are contained in the entry stored
+            at `key` in the specified table. This method will wait for the
+            fields to exist.
+
+            Args:
+                table_name (str): The name of the table where the entry is
+                    stored.
+                key (str): The key that maps to the entry being checked.
+                expected_fields (dict): The fields and their values we expect
+                    to see in the entry.
+                polling_config (PollingConfig): The parameters to use to poll
+                    the db.
+
+            Returns:
+                Dict[str, str]: The entry stored at `key`. If no entry is found,
+                then an empty Dict will be returned.
+        """
+
+        def _access_function():
+            fv_pairs = self.get_entry(table_name, key)
+            return (all(fv_pairs.get(k) == v for k, v in expected_fields.items()), fv_pairs)
+
+        status, result = wait_for_result(_access_function,
+                                         self._disable_strict_polling(polling_config))
+
+        if not status:
+            assert not polling_config.strict, \
+                "Expected fields not found: expected={}, received={}, \
+                key=\"{}\", table=\"{}\"".format(expected_fields, result, key, table_name)
+
+        return result
+
+    def wait_for_exact_match(self,
+                             table_name,
+                             key,
+                             expected_entry,
+                             polling_config=DEFAULT_POLLING_CONFIG):
+        """
+            Checks if the provided entry matches the entry stored at `key`
+            in the specified table. This method will wait for the exact entry
+            to exist.
+
+            Args:
+                table_name (str): The name of the table where the entry is
+                    stored.
+                key (str): The key that maps to the entry being checked.
+                expected_entry (dict): The entry we expect to see.
+                polling_config (PollingConfig): The parameters to use to poll
+                    the db.
+
+            Returns:
+                Dict[str, str]: The entry stored at `key`. If no entry is found,
+                then an empty Dict will be returned.
+        """
+
+        def _access_function():
+            fv_pairs = self.get_entry(table_name, key)
+            return (fv_pairs == expected_entry, fv_pairs)
+
+        status, result = wait_for_result(_access_function,
+                                         self._disable_strict_polling(polling_config))
+
+        if not status:
+            assert not polling_config.strict, \
+                "Exact match not found: expected={}, received={}, \
+                key=\"{}\", table=\"{}\"".format(expected_entry, result, key, table_name)
+
+        return result
+
+    def wait_for_deleted_entry(self,
+                               table_name,
+                               key,
+                               polling_config=DEFAULT_POLLING_CONFIG):
+        """
+            Checks if there is any entry stored at `key` in the specified
+            table. This method will wait for the entry to be empty.
+
+            Args:
+                table_name (str): The name of the table being checked.
+                key (str): The key to be checked.
+                polling_config (PollingConfig): The parameters to use to poll
+                    the db.
+
+            Returns:
+                Dict[str, str]: The entry stored at `key`. If no entry is found,
+                then an empty Dict will be returned.
+        """
+
+        def _access_function():
+            fv_pairs = self.get_entry(table_name, key)
+            return (not bool(fv_pairs), fv_pairs)
+
+        status, result = wait_for_result(_access_function,
+                                         self._disable_strict_polling(polling_config))
+
+        if not status:
+            assert not polling_config.strict, \
+                "Entry still exists: entry={}, key=\"{}\", table=\"{}\""\
+                .format(result, key, table_name)
+
+        return result
+
+    def wait_for_n_keys(self,
+                        table_name,
+                        num_keys,
+                        polling_config=DEFAULT_POLLING_CONFIG):
+        """
+            Gets all of the keys stored in the specified table. This method
+            will wait for the specified number of keys.
+
+            Args:
+                table_name (str): The name of the table from which to fetch
+                    the keys.
+                num_keys (int): The expected number of keys to retrieve from
+                    the table.
+                polling_config (PollingConfig): The parameters to use to poll
+                    the db.
+
+            Returns:
+                List[str]: The keys stored in the table. If no keys are found,
+                then an empty List will be returned.
+        """
+
+        def _access_function():
+            keys = self.get_keys(table_name)
+            return (len(keys) == num_keys, keys)
+
+        status, result = wait_for_result(_access_function,
+                                         self._disable_strict_polling(polling_config))
+
+        if not status:
+            assert not polling_config.strict, \
+                "Unexpected number of keys: expected={}, received={} ({}), table=\"{}\""\
+                .format(num_keys, len(result), result, table_name)
+
+        return result
+
+    def wait_for_matching_keys(self,
+                               table_name,
+                               expected_keys,
+                               polling_config=DEFAULT_POLLING_CONFIG):
+        """
+            Checks if the specified keys exist in the table. This method
+            will wait for the keys to exist.
+
+            Args:
+                table_name (str): The name of the table from which to fetch
+                    the keys.
+                expected_keys (List[str]): The keys we expect to see in the
+                    table.
+                polling_config (PollingConfig): The parameters to use to poll
+                    the db.
+
+            Returns:
+                List[str]: The keys stored in the table. If no keys are found,
+                then an empty List will be returned.
+        """
+
+        def _access_function():
+            keys = self.get_keys(table_name)
+            return (all(key in keys for key in expected_keys), keys)
+
+        status, result = wait_for_result(_access_function,
+                                         self._disable_strict_polling(polling_config))
+
+        if not status:
+            assert not polling_config.strict, \
+                "Expected keys not found: expected={}, received={}, table=\"{}\""\
+                .format(expected_keys, result, table_name)
+
+        return result
+
+    def wait_for_deleted_keys(self,
+                              table_name,
+                              deleted_keys,
+                              polling_config=DEFAULT_POLLING_CONFIG):
+        """
+            Checks if the specified keys no longer exist in the table. This
+            method will wait for the keys to be deleted.
+
+            Args:
+                table_name (str): The name of the table from which to fetch
+                    the keys.
+                deleted_keys (List[str]): The keys we expect to be removed from
+                    the table.
+                polling_config (PollingConfig): The parameters to use to poll
+                    the db.
+
+            Returns:
+                List[str]: The keys stored in the table. If no keys are found,
+                then an empty List will be returned.
+        """
+
+        def _access_function():
+            keys = self.get_keys(table_name)
+            return (all(key not in keys for key in deleted_keys), keys)
+
+        status, result = wait_for_result(_access_function,
+                                         self._disable_strict_polling(polling_config))
+
+        if not status:
+            assert not polling_config.strict, \
+                "Unexpected keys found: expected={}, received={}, table=\"{}\""\
+                .format(deleted_keys, result, table_name)
+
+        return result
+
+    @staticmethod
+    def _disable_strict_polling(polling_config):
+        disabled_config = PollingConfig(polling_interval=polling_config.polling_interval,
+                                        timeout=polling_config.timeout,
+                                        strict=False)
+        return disabled_config


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Commit1:
Copied dvslib directory in sonic-swss/tests directory of azure/sonic-swss repo master branch.
Latest commit id of Azure/master branch when I copied this file: 0e0f039b2eaa951f42361dfe1dc1f59780768f44

Note that I also, had to pick few modifications done to conftest.py.

Below are the 7 PRs, which contributed to dvslib directory:
PR#1213, PR#1228, PR#1233, PR#1241, PR#1254, PR#1258, PR#1243

Commit 2:
test_port_dpb_acl.py file was modified/updated when upstreamed as we were asked to use the dvslib functions to verify things instead putting sleep and verifying ourselves. Here I pulled in those changes. Note: I did NOT cherry-pick that commit because it also contains changes done to test_acl.py which I do NOT want to pull.

**Why I did it**
So, that we can write DPB test cases using this library. And when do NOT have to change our test cases when we upstream the code.

**How I verified it**
Ran test_port_dpb_acl.py and test_acl.py test cases

**Details if related**
```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -v --pdb --dvsname=vs-va test_port_dpb_acl.py
================================================================================== test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 5 items

test_port_dpb_acl.py::TestPortDPBAcl::test_acl_table_empty_port_list remove extra link dummy
PASSED                                                                                                       [ 20%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_two_acl_tables PASSED                                                                                                         [ 40%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_acl_table_many_ports PASSED                                                                                                        [ 60%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_many_acl_tables PASSED                                                                                                        [ 80%]
test_port_dpb_acl.py::TestPortDPBAcl::test_many_ports_many_acl_tables PASSED                                                                                                      [100%]

============================================================================== 5 passed in 319.82 seconds ===============================================================================
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -v --pdb --dvsname=vs-va test_acl.py
================================================================================== test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 24 items

test_acl.py::TestAcl::test_AclTableCreation remove extra link dummy
PASSED                                                                                                                                [  4%]
test_acl.py::TestAcl::test_AclRuleL4SrcPort PASSED                                                                                                                                [  8%]
test_acl.py::TestAcl::test_AclRuleInOutPorts PASSED                                                                                                                               [ 12%]
test_acl.py::TestAcl::test_AclRuleInPortsNonExistingInterface PASSED                                                                                                              [ 16%]
test_acl.py::TestAcl::test_AclRuleOutPortsNonExistingInterface PASSED                                                                                                             [ 20%]
test_acl.py::TestAcl::test_AclTableDeletion PASSED                                                                                                                                [ 25%]
test_acl.py::TestAcl::test_V6AclTableCreation PASSED                                                                                                                              [ 29%]
test_acl.py::TestAcl::test_V6AclRuleIPv6Any PASSED                                                                                                                                [ 33%]
test_acl.py::TestAcl::test_V6AclRuleIPv6AnyDrop PASSED                                                                                                                            [ 37%]
test_acl.py::TestAcl::test_V6AclRuleIpProtocol PASSED                                                                                                                             [ 41%]
test_acl.py::TestAcl::test_V6AclRuleSrcIPv6 PASSED                                                                                                                                [ 45%]
test_acl.py::TestAcl::test_V6AclRuleDstIPv6 PASSED                                                                                                                                [ 50%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPort PASSED                                                                                                                              [ 54%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPort PASSED                                                                                                                              [ 58%]
test_acl.py::TestAcl::test_V6AclRuleTCPFlags PASSED                                                                                                                               [ 62%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPortRange PASSED                                                                                                                         [ 66%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPortRange PASSED                                                                                                                         [ 70%]
test_acl.py::TestAcl::test_V6AclTableDeletion PASSED                                                                                                                              [ 75%]
test_acl.py::TestAcl::test_InsertAclRuleBetweenPriorities PASSED                                                                                                                  [ 79%]
test_acl.py::TestAcl::test_RulesWithDiffMaskLengths PASSED                                                                                                                        [ 83%]
test_acl.py::TestAcl::test_AclRuleIcmp PASSED                                                                                                                                     [ 87%]
test_acl.py::TestAcl::test_AclRuleIcmpV6 PASSED                                                                                                                                   [ 91%]
test_acl.py::TestAcl::test_AclRuleRedirectToNexthop PASSED                                                                                                                        [ 95%]
test_acl.py::TestAclRuleValidation::test_AclActionValidation PASSED                                                                                                               [100%]

============================================================================== 24 passed in 226.83 seconds ==============================================================================
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$
```