### PR TITLE
Bring up server eth devices up.

### DIFF
--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -93,6 +93,8 @@ class TestRoute(object):
         # bring up interface
         self.set_admin_status("Ethernet0", "up")
         self.set_admin_status("Ethernet4", "up")
+        dvs.servers[0].runcmd("ip link set dev eth0 up")
+        dvs.servers[1].runcmd("ip link set dev eth0 up")
 
         # set ip address and default route
         dvs.servers[0].runcmd("ip address add 10.0.0.1/31 dev eth0")


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixtes route test case by bring server eth devices up
**Why I did it**
When I ran test_route.py alone on my personal VS container or Jenkins container, it walways found. But when run with DPB smoketest, it always failed. The reason for failure was server0 eth0 device being down. Now, instead of fining out which previous test case left it down, we better bring it up in route test case. 

**How I verified it**
Brout the server0 eth0 device down and ran the test_route.py in vs-jk container.

**Details if related**
```
falco@server09:~/jenkins/workspace/DPB smoke test/sonic-buildimage/src/sonic-swss/tests$ sudo ip netns exec sw-jk-srv0 ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
22976: eth0@if22975: <BROADCAST,MULTICAST> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether c6:45:87:27:01:12 brd ff:ff:ff:ff:ff:ff link-netnsid 1
falco@server09:~/jenkins/workspace/DPB smoke test/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -v --pdb test_route.py --dvsname=vs-jk --junitxml=report.xml
===================================================================================================== test session starts ======================================================================================================
platform linux2 -- Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/falco/jenkins/workspace/DPB smoke test/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 5 items

test_route.py::TestRoute::test_RouteAddRemoveIpv4Route PASSED                                                                                                                                                            [ 20%]
test_route.py::TestRoute::test_RouteAddRemoveIpv6Route PASSED                                                                                                                                                            [ 40%]
test_route.py::TestRoute::test_RouteAddRemoveIpv4RouteWithVrf PASSED                                                                                                                                                     [ 60%]
test_route.py::TestRoute::test_RouteAddRemoveIpv6RouteWithVrf PASSED                                                                                                                                                     [ 80%]
test_route.py::TestRoute::test_RouteAndNexthopInDifferentVrf PASSED                                                                                                                                                      [100%]

------------------------------------------------------ generated xml file: /home/falco/jenkins/workspace/DPB smoke test/sonic-buildimage/src/sonic-swss/tests/report.xml -------------------------------------------------------
================================================================================================== 5 passed in 188.30 seconds ==================================================================================================
falco@server09:~/jenkins/workspace/DPB smoke test/sonic-buildimage/src/sonic-swss/tests$
```
