### PR TITLE
Get initial speed from ASIC DB

### DIFF
--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -37,8 +37,6 @@ class TestSpeedSet(object):
             if len(configured_speed_list):
                 break;
 
-        import pdb
-        pdb.set_trace()
         buffer_profiles = cfg_buffer_profile_table.getKeys()
         expected_buffer_profiles_num = len(buffer_profiles)
         # buffers_config.j2 used for the test defines 3 static profiles and 1 dynamic profiles:

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -16,7 +16,7 @@ import os
 class TestSpeedSet(object):
     num_ports = 32
     def test_SpeedAndBufferSet(self, dvs, testlog):
-        configured_speed_list = ['40000']
+        configured_speed_list = []
         speed_list = ['10000', '25000', '40000', '50000', '100000']
 
         cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
@@ -27,6 +27,18 @@ class TestSpeedSet(object):
         asic_port_table = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
         asic_profile_table = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE")
 
+        asic_port_records = asic_port_table.getKeys()
+        for k in asic_port_records:
+            (status, fvs) = asic_port_table.get(k)
+            assert status == True
+            for fv in fvs:
+                if fv[0] == "SAI_PORT_ATTR_SPEED":
+                    configured_speed_list.append(fv[1])
+            if len(configured_speed_list):
+                break;
+
+        import pdb
+        pdb.set_trace()
         buffer_profiles = cfg_buffer_profile_table.getKeys()
         expected_buffer_profiles_num = len(buffer_profiles)
         # buffers_config.j2 used for the test defines 3 static profiles and 1 dynamic profiles:

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -27,6 +27,9 @@ class TestSpeedSet(object):
         asic_port_table = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
         asic_profile_table = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE")
 
+        # Get speed from the first port we hit in ASIC DB port walk, and
+        # assume that its the initial configured speed for all ports, and
+        # dynamic buffer profile has already been created for it.
         asic_port_records = asic_port_table.getKeys()
         for k in asic_port_records:
             (status, fvs) = asic_port_table.get(k)
@@ -34,6 +37,8 @@ class TestSpeedSet(object):
             for fv in fvs:
                 if fv[0] == "SAI_PORT_ATTR_SPEED":
                     configured_speed_list.append(fv[1])
+                    break
+
             if len(configured_speed_list):
                 break;
 
@@ -43,7 +48,7 @@ class TestSpeedSet(object):
         #    "ingress_lossy_profile"
         #    "egress_lossless_profile"
         #    "egress_lossy_profile"
-        #    "pg_lossless_40000_300m_profile"
+        #    "pg_lossless_<initial_speed>_300m_profile"
         # check if they get the DB
         assert expected_buffer_profiles_num == 4
         # and if they were successfully created on ASIC


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Initialized the configured speed list by reading port speed from ASIC DB

**Why I did it**

Since Speed is introduced in port_config.ini of VS platform, one of the buffer profiles is already created(speed 40G). Hence the test case is modified in gitHUB 201911 and master branches. The list of speeds is [10G, 25G, 40G, 50G, 100G], initial number of buffer profiles present is 4 (including the one created for 40G)
Test case walks through each speed and configures that speed on all the ports. Expects that a new buffer profile is created when a new speed is set on all ports. But note that since 40G profiles is already created, it expects no new buffer profile to be created when we set 40G on all ports.

Now, when we walk through the speed list, This is what happens

10G - yes a new profile is created
25G - yes, a new profile is created
40G - yes, a new profile is created. This is the problem!

Root cause: In our branch the initial created buffer profile is NOT for 40G, instead it is for 100G. 
Because we are setting different speed for ports in platform.json 
**How I verified it**
By running the VS test case
**Details if related**
```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -v --pdb --dvsname=vs-vp test_speed.py -k test_SpeedAndBufferSet
================================================================================== test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 1 item                                                                                                                                                                        

test_speed.py::TestSpeedSet::test_SpeedAndBufferSet remove extra link dummy

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests/test_speed.py(42)test_SpeedAndBufferSet()
-> buffer_profiles = cfg_buffer_profile_table.getKeys()
(Pdb) list
 37                 if len(configured_speed_list):
 38                     break;
 39  
 40             import pdb
 41             pdb.set_trace()
 42  ->         buffer_profiles = cfg_buffer_profile_table.getKeys()
 43             expected_buffer_profiles_num = len(buffer_profiles)
 44             # buffers_config.j2 used for the test defines 3 static profiles and 1 dynamic profiles:
 45             #    "ingress_lossy_profile"
 46             #    "egress_lossless_profile"
 47             #    "egress_lossy_profile"
(Pdb) p configured_speed_list
['100000']
(Pdb) c
PASSED                                                                                                                        [100%]Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f3efdc3c930>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f3efdc3c930> = <_sre.SRE_Match object at 0x7f3efdc3c930>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f3efdb2c7d0>> ignored


============================================================================== 1 passed in 179.38 seconds ===============================================================================
```

```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -v --pdb --dvsname=vs-vp test_speed.py -k test_SpeedAndBufferSet
================================================================================== test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 1 item

test_speed.py::TestSpeedSet::test_SpeedAndBufferSet remove extra link dummy
PASSED                                                                                                                        [100%]Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f3eada69930>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f3eada69930> = <_sre.SRE_Match object at 0x7f3eada69930>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f3eada9e2d0>> ignored


=============================================================================== 1 passed in 54.28 seconds ===============================================================================
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$
```