### PR TITLE
DPB VLAN system test case and pulled in VLAN related DVSLIB code

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,8 @@ from swsscommon import swsscommon
 
 from dvslib import dvs_database as dvs_db
 from dvslib import dvs_acl
+from dvslib import dvs_vlan
+from dvslib import dvs_lag
 
 def ensure_system(cmd):
     rc = os.WEXITSTATUS(os.system(cmd))
@@ -1044,12 +1046,26 @@ def testlog(request, dvs):
     yield testlog
     dvs.runcmd("logger === finish test %s ===" % request.node.name)
 
+
+################# DVSLIB module manager fixtures #############################
 @pytest.yield_fixture(scope="class")
 def dvs_acl_manager(request, dvs):
     request.cls.dvs_acl = dvs_acl.DVSAcl(dvs.get_asic_db(),
                                          dvs.get_config_db(),
                                          dvs.get_state_db(),
                                          dvs.get_counters_db())
+
+@pytest.yield_fixture(scope="class")
+def dvs_lag_manager(request, dvs):
+    request.cls.dvs_lag = dvs_lag.DVSLag(dvs.get_config_db())
+
+@pytest.yield_fixture(scope="class")
+def dvs_vlan_manager(request, dvs):
+    request.cls.dvs_vlan = dvs_vlan.DVSVlan(dvs.get_asic_db(),
+                                            dvs.get_config_db(),
+                                            dvs.get_state_db(),
+                                            dvs.get_counters_db(),
+                                            dvs.get_app_db())
 
 ##################### DPB fixtures ###########################################
 @pytest.yield_fixture(scope="module")

--- a/tests/dvslib/dvs_lag.py
+++ b/tests/dvslib/dvs_lag.py
@@ -1,0 +1,21 @@
+class DVSLag(object):
+    def __init__(self, cdb):
+        self.config_db = cdb
+
+    def create_port_channel(self, lag_id, admin_status="up", mtu="1500"):
+        lag = "PortChannel{}".format(lag_id)
+        lag_entry = {"admin_status": admin_status, "mtu": mtu}
+        self.config_db.create_entry("PORTCHANNEL", lag, lag_entry)
+
+    def remove_port_channel(self, lag_id):
+        lag = "PortChannel{}".format(lag_id)
+        self.config_db.delete_entry("PORTCHANNEL", lag)
+
+    def create_port_channel_member(self, lag_id, interface):
+        member = "PortChannel{}|{}".format(lag_id, interface)
+        member_entry = {"NULL": "NULL"}
+        self.config_db.create_entry("PORTCHANNEL_MEMBER", member, member_entry)
+
+    def remove_port_channel_member(self, lag_id, interface):
+        member = "PortChannel{}|{}".format(lag_id, interface)
+        self.config_db.delete_entry("PORTCHANNEL_MEMBER", member)

--- a/tests/dvslib/dvs_vlan.py
+++ b/tests/dvslib/dvs_vlan.py
@@ -30,24 +30,6 @@ class DVSVlan(object):
         member = "Vlan{}|{}".format(vlan, interface)
         self.config_db.delete_entry("VLAN_MEMBER", member)
 
-    def create_port_channel(self, lag_id, admin_status="up", mtu="1500"):
-        lag = "PortChannel{}".format(lag_id)
-        lag_entry = {"admin_status": admin_status, "mtu": mtu}
-        self.config_db.create_entry("PORTCHANNEL", lag, lag_entry)
-
-    def remove_port_channel(self, lag_id):
-        lag = "PortChannel{}".format(lag_id)
-        self.config_db.delete_entry("PORTCHANNEL", lag)
-
-    def create_port_channel_member(self, lag_id, interface):
-        member = "PortChannel{}|{}".format(lag_id, interface)
-        member_entry = {"NULL": "NULL"}
-        self.config_db.create_entry("PORTCHANNEL_MEMBER", member, member_entry)
-
-    def remove_port_channel_member(self, lag_id, interface):
-        member = "PortChannel{}|{}".format(lag_id, interface)
-        self.config_db.delete_entry("PORTCHANNEL_MEMBER", member)
-
     def check_app_db_vlan_fields(self, fvs, admin_status="up", mtu="9100"):
         assert fvs.get("admin_status") == admin_status
         assert fvs.get("mtu") == mtu

--- a/tests/dvslib/dvs_vlan.py
+++ b/tests/dvslib/dvs_vlan.py
@@ -1,0 +1,94 @@
+from dvs_database import DVSDatabase
+
+class DVSVlan(object):
+    def __init__(self, adb, cdb, sdb, cntrdb, appdb):
+        self.asic_db = adb
+        self.config_db = cdb
+        self.state_db = sdb
+        self.counters_db = cntrdb
+        self.app_db = appdb
+
+    def create_vlan(self, vlanID):
+        vlanName = "Vlan{}".format(vlanID)
+        vlan_entry = {"vlanid": vlanID}
+        self.config_db.create_entry("VLAN", vlanName, vlan_entry)
+
+    def remove_vlan(self, vlanID):
+        vlanName = "Vlan{}".format(vlanID)
+        self.config_db.delete_entry("VLAN", vlanName)
+
+    def create_vlan_member(self, vlan, interface, tagging_mode="untagged"):
+        member = "Vlan{}|{}".format(vlan, interface)
+        if tagging_mode:
+            member_entry = {"tagging_mode": tagging_mode}
+        else:
+            member_entry = {"no_tag_mode": ""}
+
+        self.config_db.create_entry("VLAN_MEMBER", member, member_entry)
+
+    def remove_vlan_member(self, vlan, interface):
+        member = "Vlan{}|{}".format(vlan, interface)
+        self.config_db.delete_entry("VLAN_MEMBER", member)
+
+    def create_port_channel(self, lag_id, admin_status="up", mtu="1500"):
+        lag = "PortChannel{}".format(lag_id)
+        lag_entry = {"admin_status": admin_status, "mtu": mtu}
+        self.config_db.create_entry("PORTCHANNEL", lag, lag_entry)
+
+    def remove_port_channel(self, lag_id):
+        lag = "PortChannel{}".format(lag_id)
+        self.config_db.delete_entry("PORTCHANNEL", lag)
+
+    def create_port_channel_member(self, lag_id, interface):
+        member = "PortChannel{}|{}".format(lag_id, interface)
+        member_entry = {"NULL": "NULL"}
+        self.config_db.create_entry("PORTCHANNEL_MEMBER", member, member_entry)
+
+    def remove_port_channel_member(self, lag_id, interface):
+        member = "PortChannel{}|{}".format(lag_id, interface)
+        self.config_db.delete_entry("PORTCHANNEL_MEMBER", member)
+
+    def check_app_db_vlan_fields(self, fvs, admin_status="up", mtu="9100"):
+        assert fvs.get("admin_status") == admin_status
+        assert fvs.get("mtu") == mtu
+
+    def check_app_db_vlan_member_fields(self, fvs, tagging_mode="untagged"):
+        assert fvs.get("tagging_mode") == tagging_mode
+
+    def check_state_db_vlan_fields(self, fvs, state="ok"):
+        assert fvs.get("state") == state
+
+    def check_state_db_vlan_member_fields(self, fvs, state="ok"):
+        assert fvs.get("state") == state
+
+    def verify_vlan(self, vlan_oid, vlan_id):
+        vlan = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_VLAN", vlan_oid)
+        assert vlan.get("SAI_VLAN_ATTR_VLAN_ID") == vlan_id
+
+    def get_and_verify_vlan_ids(self,
+                                expected_num,
+                                polling_config=DVSDatabase.DEFAULT_POLLING_CONFIG):
+        vlan_entries = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_VLAN",
+                                                    expected_num + 1,
+                                                    polling_config)
+        return [v for v in vlan_entries if v != self.asic_db.default_vlan_id]
+
+    def verify_vlan_member(self, vlan_oid, iface, tagging_mode="SAI_VLAN_TAGGING_MODE_UNTAGGED"):
+        member_ids = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_VLAN_MEMBER", 1)
+        member = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_VLAN_MEMBER", member_ids[0])
+        assert member == {"SAI_VLAN_MEMBER_ATTR_VLAN_TAGGING_MODE": tagging_mode,
+                          "SAI_VLAN_MEMBER_ATTR_VLAN_ID": vlan_oid,
+                          "SAI_VLAN_MEMBER_ATTR_BRIDGE_PORT_ID": self.get_bridge_port_id(iface)}
+
+    def get_and_verify_vlan_member_ids(self, expected_num):
+        return self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_VLAN_MEMBER", expected_num)
+
+    def get_bridge_port_id(self, expected_iface):
+        bridge_port_id = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_BRIDGE_PORT", 1)[0]
+        bridge_port = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_BRIDGE_PORT", bridge_port_id)
+        #TBD: port_to_id_map may NOT be updated one in case port is deleted and re-created.
+        #     Hence the map needs refreshed. Need to think trough and decide when and where
+        #     to do it.
+        assert self.asic_db.port_to_id_map[bridge_port["SAI_BRIDGE_PORT_ATTR_PORT_ID"]] == expected_iface
+        return bridge_port_id
+


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Pulled in VLAN related DVSLIB files from an upstream PR in to this
Wrote VLAN DPB system test case using the CLI
**Why I did it**
To test VLAN dependency on DPB via CLI
**How I verified it**
By running the VS test case
**Details if related**
```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -v --pdb --dvsname=vs-jk test_port_dpb_system.py -k test_port_breakout_with_vlan
================================================================================== test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 7 items                                                                                                                                                                       

test_port_dpb_system.py::TestPortDPBSystem::test_port_breakout_with_vlan remove extra link dummy
remove extra link Vlan100@Bridge
PASSED                                                                                                   [100%]

================================================================================== 6 tests deselected ===================================================================================
======================================================================= 1 passed, 6 deselected in 100.85 seconds ========================================================================
```
