### PR TITLE
FLUSH FDB entries based on bridge port

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3220,6 +3220,9 @@ bool PortsOrch::removeBridgePort(Port &port)
         return false;
     }
 
+    /* Flush FDB entries pointing to this bridge port */
+    flushFDBEntries(port);
+
     /* Remove bridge port */
     status = sai_bridge_api->remove_bridge_port(port.m_bridge_port_id);
     if (status != SAI_STATUS_SUCCESS)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Flush FDB entries based on bridge port
**Why I did it**
Because we were unable to delete bridge port even after removing port from all VLANs. Because FDB entries were still dependent on bridge port
**How I verified it**
By running VS test cases

**Details if related**
```

vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -v --pdb --dvsname=vs-jk test_port_dpb_vlan.py -k test_all_port_10_vlans
================================================================================== test session starts ==================================================================================
platform linux2 – Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 – /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 4 items

test_port_dpb_vlan.py::TestPortDPBVlan::test_all_port_10_vlans remove extra link dummy
FAILED [100%]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

self = <test_port_dpb_vlan.TestPortDPBVlan object at 0x7fcf6ec6e750>, dvs = <conftest.DockerVirtualSwitch object at 0x7fcf6ec6e9d0>

def test_all_port_10_vlans(self, dvs):
num_vlans = 10
start_vlan = 100
num_ports = 32
port_names = []
vlan_names = []

dvs.setup_db()
for i in range(num_ports):
port_names.append("Ethernet" + str(i*4))

for i in range(num_vlans):
vlan_names.append(str(start_vlan + i))

for vlan_name in vlan_names:
dvs.create_vlan(vlan_name)
#print "%d VLANs created"%num_vlans

for port_name in port_names:
for vlan_name in vlan_names:
dvs.create_vlan_member_tagged(vlan_name, port_name)
#print "All %d ports are added to all %d VLANs"%(num_ports,num_vlans)

ports = []
for port_name in port_names:
p = Port(dvs, port_name)
ports.append(p)
p.sync_from_config_db()
p.delete_from_config_db()
#print "Deleted %s from config DB"%port_name
assert(p.exists_in_config_db() == False)
assert(p.exists_in_app_db() == False)
assert(p.exists_in_asic_db() == True)
for vlan_name in vlan_names:
dvs.remove_vlan_member(vlan_name, port_name)
time.sleep(1)
> assert(p.exists_in_asic_db() == False)
E assert True == False
E + where True = <bound method Port.exists_in_asic_db of <port_dpb.Port instance at 0x7fcf6ec34f50>>()
E + where <bound method Port.exists_in_asic_db of <port_dpb.Port instance at 0x7fcf6ec34f50>> = <port_dpb.Port instance at 0x7fcf6ec34f50>.exists_in_asic_db

```

 

After fix:
```

vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -v --pdb --dvsname=vs-jk test_port_dpb_vlan.py -k test_all_port_10_vlans
================================================================================== test session starts ==================================================================================
platform linux2 – Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 – /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 4 items

test_port_dpb_vlan.py::TestPortDPBVlan::test_all_port_10_vlans remove extra link dummy
PASSED [100%]

================================================================================== 3 tests deselected ===================================================================================
======================================================================= 1 passed, 3 deselected in 915.66 seconds ========================================================================
```